### PR TITLE
Fix KUBECONFIG and CONTAINERD_ADDRESS variables

### DIFF
--- a/files/etc/bash.bashrc.local
+++ b/files/etc/bash.bashrc.local
@@ -1,8 +1,9 @@
 if [ -z "$KUBECONFIG" ]; then
     if [ -e /etc/rancher/rke2 ]; then
         export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+    else
+        export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
     fi
-    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 fi
 if [ -d /var/lib/rancher/rke2/bin ]; then
     export PATH="${PATH}:/var/lib/rancher/rke2/bin"
@@ -12,4 +13,9 @@ if [ -z "$CONTAINER_RUNTIME_ENDPOINT" ]; then
 fi
 if [ -z "$IMAGE_SERVICE_ENDPOINT" ]; then
     export IMAGE_SERVICE_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock
+fi
+
+# For ctr
+if [ -z "$CONTAINERD_ADDRESS" ]; then
+    export CONTAINERD_ADDRESS=/run/k3s/containerd/containerd.sock
 fi


### PR DESCRIPTION
It's easier to use `kubectl` and `ctr` commands this way.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>