### PR TITLE
Pull latest luet version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN zypper in -y traceroute \
 ARG CACHEBUST
 RUN luet install -y \
     toolchain/yip \
+    toolchain/luet \
     utils/installer \
     system/cos-setup \
     system/immutable-rootfs \


### PR DESCRIPTION
In this way there is no need to manually pinpoint to luet versions with LUET_VERSION, but would be just used as a bootstrap version to get the latest available on the cOS repositories