### PR TITLE
Add microcode packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,8 @@ RUN zypper in -y kernel-firmware-chelsio \
     kernel-firmware-mediatek \
     kernel-firmware-marvell \
     kernel-firmware-qlogic \
-    kernel-firmware-usb-network
+    kernel-firmware-usb-network \
+    ucode-intel ucode-amd
 
 # Harvester needs these packages
 RUN zypper in -y apparmor-parser \


### PR DESCRIPTION
Harvester is supposed to run on bare-metal machines, patching CPU microcodes is recommended.

**Related issue**
https://github.com/harvester/harvester/issues/1341