### PR TITLE
Pin rancherd to 0.0.1-alpha07-9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ RUN luet install -y \
     selinux/rancher \
     utils/k9s \
     utils/nerdctl \
-    utils/rancherd
+    utils/rancherd@0.0.1-alpha07-9
 
 # Create the folder for journald persistent data
 RUN mkdir -p /var/log/journal


### PR DESCRIPTION
This is a temporary workaround to keep rancherd in the old version (same as the one in Harvester `0.3.0-rc1`) until https://github.com/harvester/harvester-installer/pull/146 is well-tested.