### PR TITLE
Pin installer to 0.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ ARG CACHEBUST
 RUN luet install -y \
     toolchain/yip \
     toolchain/luet \
-    utils/installer \
+    utils/installer@0.18 \
     system/cos-setup \
     system/immutable-rootfs \
     system/grub2-config \


### PR DESCRIPTION
We need the `--force-gpt` option of `cos-installer`.

Signed-off-by: John Liu <john.liu@suse.com>