### PR TITLE
Do not enable overlay paths in debugrw mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN luet install -y \
     toolchain/luet \
     utils/installer@0.18 \
     system/cos-setup \
-    system/immutable-rootfs \
+    system/immutable-rootfs@0.2.0-11 \
     system/grub2-config \
     selinux/k3s \
     selinux/rancher \

--- a/files/system/oem/00_rootfs.yaml
+++ b/files/system/oem/00_rootfs.yaml
@@ -38,6 +38,11 @@ stages:
       environment:
         VOLUMES: "LABEL=COS_OEM:/oem"
         OVERLAY: "tmpfs:25%"
+    - if: 'grep -q root=LABEL=COS_ACTIVE /proc/cmdline && grep -q rd.cos.debugrw /proc/cmdline'
+      name: "Layout configuration for debugrw"
+      environment_file: /run/cos/cos-layout.env
+      environment:
+        RW_PATHS: ""
   initramfs:
     - if: '[ ! -f "/run/cos/recovery_mode" ]'
       name: "Persist /etc/machine-id"


### PR DESCRIPTION
Disable volatile overlayfs on paths specified in `RW_PATHS` variable.

Related issue: https://github.com/harvester/harvester/issues/1388

**Test plan**

- Build an ISO based on this image.
- Follow the [guide](https://docs.harvesterhci.io/v0.3/troubleshooting/os/#how-can-i-install-packages-why-are-some-paths-read-only) to enable rw mode. **Skip** the `/oem/91_hack.yaml` workaround.
- After booting into the system, there should be no overlaid directories.
```
node1:~ # mount | grep overlay
tmpfs on /run/overlay type tmpfs (rw,relatime,size=2035532k)
```