### PR TITLE
Upgrade luet packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY tools /
 RUN luet install -y toolchain/luet-makeiso
 
 FROM base
+ARG RANCHERD_VERSION=v0.0.1-alpha07
 RUN zypper in -y \
     bash-completion \
     conntrack-tools \
@@ -116,8 +117,10 @@ RUN luet install -y \
     selinux/rancher \
     utils/k9s \
     utils/nerdctl \
-    utils/rancherd@0.0.1-alpha11-2 \
     toolchain/yq
+
+# Download rancherd binary to pin the version
+RUN curl -o /usr/bin/rancherd -sfL "https://github.com/rancher/rancherd/releases/download/${RANCHERD_VERSION}/rancherd-amd64" && chmod 0755 /usr/bin/rancherd
 
 # Create the folder for journald persistent data
 RUN mkdir -p /var/log/journal

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,15 +108,15 @@ ARG CACHEBUST
 RUN luet install -y \
     toolchain/yip \
     toolchain/luet \
-    utils/installer@0.18 \
+    utils/installer@0.21 \
     system/cos-setup \
-    system/immutable-rootfs@0.2.0-11 \
+    system/immutable-rootfs@0.2.0-12 \
     system/grub2-config \
     selinux/k3s \
     selinux/rancher \
     utils/k9s \
     utils/nerdctl \
-    utils/rancherd@0.0.1-alpha07-9 \
+    utils/rancherd@0.0.1-alpha11-2 \
     toolchain/yq
 
 # Create the folder for journald persistent data


### PR DESCRIPTION
Mainly need to upgrade `utils/installer` for the custom partition layout feature. Upgrade other pinned packages because the older versions are removed from luet repo.

**Note:** Since it requires extra effort to upgrade `rancherd`, we decided to pin down its version. Because Luet no longer provides that version from the current index, we need to manually pull the binary from GitHub.