### PR TITLE
Add dracut module 'ifcfg'

### DIFF
--- a/files/etc/dracut.conf.d/60-generate-ifcfg.conf
+++ b/files/etc/dracut.conf.d/60-generate-ifcfg.conf
@@ -1,0 +1,2 @@
+# This is required for Dracut to generate ifcfg files from "ip=..." kernel cmdline args
+add_dracutmodules+=" ifcfg "


### PR DESCRIPTION
To automatically generate ifcfg files from `ip=...` kernel cmdline arguments.