### PR TITLE
Allow serving ISO content with the live OS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,8 @@ RUN zypper in -y kernel-firmware-chelsio \
 
 # Harvester needs these packages
 RUN zypper in -y apparmor-parser \
-    zstd
+    zstd \
+    nginx
 
 # Additional useful packages
 RUN zypper in -y traceroute \
@@ -104,6 +105,8 @@ RUN zypper in -y traceroute \
     numactl \
     ipmitool \
     kdump
+
+RUN zypper clean
 
 ARG CACHEBUST
 RUN luet install -y \

--- a/files/etc/nginx/conf.d/iso.conf.disabled
+++ b/files/etc/nginx/conf.d/iso.conf.disabled
@@ -1,0 +1,8 @@
+# serve iso contents
+server {
+    listen       80;
+
+    location /harvester-iso/ {
+        alias /run/initramfs/live/;
+    }
+}

--- a/files/system/oem/92_iso_repo.yaml
+++ b/files/system/oem/92_iso_repo.yaml
@@ -1,0 +1,20 @@
+# start an nginx server to server ISO content if
+# - `harvester.serve_iso=true` is in kernel parameters, or
+# - `/harvester-serve-iso` file exists
+name: "serve iso content"
+stages:
+  initramfs:
+    - if: grep -q harvester.serve_iso=true /proc/cmdline || [ -e /harvester-serve-iso ]
+      directories:
+      - path: /var/log/nginx
+        permissions: 0664
+      commands:
+      - |
+        for i in /sys/class/net/{eth*,en*,ib*}; do
+          [ -e $i ] || continue
+          if_cfg="/etc/sysconfig/network/ifcfg-$(basename $i)"
+          echo "BOOTPROTO=dhcp" > $if_cfg
+          echo "STARTMODE=onboot" >> $if_cfg
+        done
+      - cp /etc/nginx/conf.d/iso.conf.disabled /etc/nginx/conf.d/iso.conf
+      - systemctl enable nginx


### PR DESCRIPTION
Setup an Nginx server to server ISO content if:
- `harvester.serve_iso=true` kernel parameter is provided.
- `/harvester-serve-iso` file exists.

During Harvester upgrade, we'll provision a VM with userdata to create
`/harvester-server-iso` file.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>