### PR TITLE
Bump utils/installer to 0.21.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ ARG CACHEBUST
 RUN luet install -y \
     toolchain/yip \
     toolchain/luet \
-    utils/installer@0.21.2 \
+    utils/installer@0.21.3 \
     system/cos-setup \
     system/immutable-rootfs@0.2.0-12 \
     system/grub2-config \


### PR DESCRIPTION
Fix GRUB rebranding issue after upgrade.
https://github.com/rancher-sandbox/cOS-toolkit/issues/928

The k9s package in the repo is also updated, which eliminates the debugging messager.