### PR TITLE
Pin Luet index to 20220107162822-repository.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG LUET_VERSION=0.16.7
-FROM quay.io/luet/base:$LUET_VERSION AS luet
+FROM quay.io/costoolkit/releases-green:luet-toolchain-0.21.2 as luet
 
 FROM opensuse/leap:15.3 AS base
 

--- a/files/etc/luet/luet.yaml
+++ b/files/etc/luet/luet.yaml
@@ -14,4 +14,5 @@ repositories:
   verify: false
   urls:
   - "quay.io/costoolkit/releases-green"
+  reference: 20220107162822-repository.yaml
 


### PR DESCRIPTION
The latest cOS packages bump seems to break Harvester. Before we figure out the root cause we can pin the index first.

This produces a base image that has Luet packages whose versions are identical to packages versions in tag 20220110.

