### PR TITLE
Temporary workaround for https://github.com/rancher/rancherd/issues/22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,8 @@ RUN luet install -y \
     toolchain/yq
 
 # Download rancherd binary to pin the version
-RUN curl -o /usr/bin/rancherd -sfL "https://github.com/rancher/rancherd/releases/download/${RANCHERD_VERSION}/rancherd-amd64" && chmod 0755 /usr/bin/rancherd
+# Workaround until https://github.com/rancher/rancherd/issues/22 is resolved.
+RUN curl -o /usr/bin/rancherd -sfL  https://github.com/bk201/rancherd/releases/download/v0.0.1-alpha07-harvester1/rancherd-amd64 && chmod 0755 /usr/bin/rancherd
 
 # Create the folder for journald persistent data
 RUN mkdir -p /var/log/journal


### PR DESCRIPTION
The code is checked out from the `v0.0.1-alpha07` tag and applies my [fix](https://github.com/bk201/rancherd/commit/809876b09d49d5bec7fe105363888ab666345244).
Note we can't checkout from the latest commit because I saw some port conflict.
We need this until the bug is resolved.