### PR TITLE
Bump Rancherd to v0.0.1-alpha13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY tools /
 RUN luet install -y toolchain/luet-makeiso
 
 FROM base
-ARG RANCHERD_VERSION=v0.0.1-alpha07
+ARG RANCHERD_VERSION=v0.0.1-alpha13
 RUN zypper in -y \
     bash-completion \
     conntrack-tools \


### PR DESCRIPTION
## Dependencies
- We need https://github.com/harvester/harvester-installer/pull/280 for `v0.0.1-alpha13` to work correctly due to https://github.com/rancher/rancherd/issues/23