### PR TITLE
persistent /etc/pki/trust/anchors

### DIFF
--- a/files/system/oem/00_rootfs.yaml
+++ b/files/system/oem/00_rootfs.yaml
@@ -19,6 +19,7 @@ stages:
           /etc/ssh
           /etc/iscsi 
           /etc/cni
+          /etc/pki/trust/anchors
           /home
           /opt
           /root


### PR DESCRIPTION
We store additional-ca under `/etc/pki/trust/anchors`. To keep it after users restart nodes, we need to add the folder as a persistent path.

https://github.com/harvester/harvester/issues/2175