### PR TITLE
Rename base image name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensuse.org/isv/rancher/harvester/baseos/main/baseos:5.2 AS base
+FROM registry.opensuse.org/isv/rancher/harvester/baseos/main/baseos:latest AS base
 
 COPY files/etc/luet/luet.yaml /etc/luet/luet.yaml
 


### PR DESCRIPTION
we could use "registry.opensuse.org/isv/rancher/harvester/baseos/<VERSION>/baseos:latest" as image name
VERSION could be main (newest) or 5.2 (corresponding SLE Micro for Rancher version)

Signed-off-by: Date Huang <date.huang@suse.com>