### PR TITLE
Bump Rancherd to v0.1.0-rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN cat /tmp/os-release >> /usr/lib/os-release && rm -f /tmp/os-release
 RUN rm -f /etc/cos/config
 
 # Download rancherd
-ARG RANCHERD_VERSION=v0.0.1-alpha14
+ARG RANCHERD_VERSION=v0.1.0-rc1
 RUN curl -o /usr/bin/rancherd -sfL "https://github.com/rancher/rancherd/releases/download/${RANCHERD_VERSION}/rancherd-amd64" && chmod 0755 /usr/bin/rancherd
 
 # Download virtctl


### PR DESCRIPTION
Fix cluster bootstrap with Rancher v2.7.5.
https://github.com/rancher/rancherd/releases/tag/v0.1.0-rc1