### PR TITLE
drone: daily build sle-micro-head image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -74,6 +74,7 @@ steps:
       - refs/heads/sle-micro
     event:
       - push
+      - cron
 
 - name: docker-publish
   image: plugins/docker


### PR DESCRIPTION
    - now the installer will use the sle-micro-head image, so we need to
      build it daily.