### PR TITLE
config: change the root label checking from COS_ACTIVE to COS_STATE

### DIFF
--- a/files/system/oem/00_rootfs.yaml
+++ b/files/system/oem/00_rootfs.yaml
@@ -39,7 +39,7 @@ stages:
       environment:
         VOLUMES: "LABEL=COS_OEM:/oem"
         OVERLAY: "tmpfs:25%"
-    - if: 'grep -q root=LABEL=COS_ACTIVE /proc/cmdline && grep -q rd.cos.debugrw /proc/cmdline'
+    - if: 'grep -q root=LABEL=COS_STATE /proc/cmdline && grep -q rd.cos.debugrw /proc/cmdline'
       name: "Layout configuration for debugrw"
       environment_file: /run/cos/cos-layout.env
       environment:


### PR DESCRIPTION
    - We introduce the new elemental-toolkit. There is a main change
      for the root label from COS_ACTIVE to COS_STATE so we need to
      change the related checking.
