### PR TITLE
oem: Include the `sshd_config.d` in default ssd config

### DIFF
--- a/files/system/oem/09_sshd.yaml
+++ b/files/system/oem/09_sshd.yaml
@@ -25,4 +25,5 @@ stages:
          X11Forwarding no
          AllowTcpForwarding no
          MaxAuthTries 3
+         Include /etc/ssh/sshd_config.d/*.conf
          EOF


### PR DESCRIPTION
    - We could do more when we want to introduce the customer setup

This commit will help us to config `sftp` dynamically.