### PR TITLE
Bump rancherd to v0.1.0-rc3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN cat /tmp/os-release >> /usr/lib/os-release && rm -f /tmp/os-release
 RUN rm -f /etc/cos/config
 
 # Download rancherd
-ARG RANCHERD_VERSION=v0.1.0-rc2
+ARG RANCHERD_VERSION=v0.1.0-rc3
 RUN curl -o /usr/bin/rancherd -sfL "https://github.com/rancher/rancherd/releases/download/${RANCHERD_VERSION}/rancherd-amd64" && chmod 0755 /usr/bin/rancherd
 
 # Download nerdctl


### PR DESCRIPTION
Able to download and install the CA file retrieved from Rancher automatically during the join-node process.