### PR TITLE
system: add cloud-init lvm config

### DIFF
--- a/files/system/oem/91_lvm.yaml
+++ b/files/system/oem/91_lvm.yaml
@@ -1,0 +1,7 @@
+name: "apply Harvester lvm config"
+stages:
+   initramfs:
+     - name: "patch lvm config (add gloabl_filter)"
+       commands:
+       - |
+        sed -i 's/^devices.*/&\n\tglobal_filter = [ "r|.*\/|" ]/' /etc/lvm/lvm.conf


### PR DESCRIPTION
related issue: https://github.com/harvester/harvester/issues/4674

Test Plan:
1. make sure the `/etc/lvm/lvm.conf` contain the following patch
```
# Configuration section devices.
# How LVM uses block devices.
devices {
        global_filter = [ "r|.*/|" ]
.
.
.
```

2. Create any VM and try to attach a volume to it. (assume that is `/dev/sda`)
3. Create LVM device on this VM by following command
```
$ pvcreate /dev/sda
$ vgcreate vg01 /dev/sda
$ lvcreate -L 500M -n lv01 vg01
```
now we can check the `/dev/sda` with lvm
```
root@vm001:~# lsblk /dev/sda
NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda           8:0    0    1G  0 disk
└─vg01-lv01 253:0    0  500M  0 lvm
```
4. Try to migrate this VM to another host.
5. We should not see any LVM device on the migration target
(If we miss this patch, we will see the following result on the host)
```
# lsblk /dev/sda /dev/sdb
NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda           8:0    0   10G  0 disk
├─sda1        8:1    0  9.9G  0 part
├─sda14       8:14   0    4M  0 part
└─sda15       8:15   0  106M  0 part
sdb           8:16   0    1G  0 disk
└─vg01-lv01 254:0    0  500M  0 lvm <-- should not see this with patched lvm.conf
```