### PR TITLE
publish driver toolkit image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -279,3 +279,283 @@ steps:
 depends_on:
   - amd64
   - arm64
+
+---
+kind: pipeline
+name: nvidia-driver-toolkit-amd64
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: docker-build
+    image: plugins/docker
+    settings:
+      dockerfile: nvidia-driver-toolkit/Dockerfile
+      repo: "rancher/harvester-os"
+      tag: "nvidia-driver-toolkit-dev-head-amd64"
+      dry_run: true
+      context: nvidia-driver-toolkit
+      build_args:
+        - ARCH=amd64
+    when:
+      instance:
+        - drone-pr.rancher.io
+      branch:
+        - dev
+
+  - name: docker-publish-dev
+    image: plugins/docker
+    settings:
+      dockerfile: nvidia-driver-toolkit/Dockerfile
+      repo: "rancher/harvester-os"
+      tag: "nvidia-driver-toolkit-dev-head-amd64"
+      context: nvidia-driver-toolkit
+      build_args:
+        - ARCH=amd64
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/heads/dev
+      event:
+        - push
+
+  - name: docker-build-sle-micro
+    image: plugins/docker
+    settings:
+      dockerfile: nvidia-driver-toolkit/Dockerfile
+      repo: "rancher/harvester-os"
+      tag: "nvidia-driver-toolkit-sle-micro-head-amd64"
+      dry_run: true
+      context: nvidia-driver-toolkit
+      build_args:
+        - ARCH=amd64
+    when:
+      instance:
+        - drone-pr.rancher.io
+      branch:
+        - sle-micro
+
+  - name: docker-publish-sle-micro
+    image: plugins/docker
+    settings:
+      dockerfile: nvidia-driver-toolkit/Dockerfile
+      repo: "rancher/harvester-os"
+      tag: "nvidia-driver-toolkit-sle-micro-head-amd64"
+      context: nvidia-driver-toolkit
+      build_args:
+        - ARCH=amd64
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/heads/sle-micro
+      event:
+        - push
+        - cron
+
+  - name: docker-publish
+    image: plugins/docker
+    settings:
+      dockerfile: nvidia-driver-toolkit/Dockerfile
+      repo: "rancher/harvester-os"
+      tag: "nvidia-driver-toolkit-${DRONE_TAG}-amd64"
+      context: nvidia-driver-toolkit
+      build_args:
+        - ARCH=amd64
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/tags/*
+      event:
+        - tag
+---
+kind: pipeline
+name: nvidia-driver-toolkit-arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+  - name: docker-build
+    image: plugins/docker
+    settings:
+      dockerfile: nvidia-driver-toolkit/Dockerfile
+      repo: "rancher/harvester-os"
+      tag: "nvidia-driver-toolkit-dev-head-arm64"
+      context: nvidia-driver-toolkit
+      dry_run: true
+      build_args:
+        - ARCH=arm64
+    when:
+      instance:
+        - drone-pr.rancher.io
+      branch:
+        - dev
+
+  - name: docker-publish-dev
+    image: plugins/docker
+    settings:
+      dockerfile: nvidia-driver-toolkit/Dockerfile
+      repo: "rancher/harvester-os"
+      tag: "nvidia-driver-toolkit-dev-head-arm64"
+      context: nvidia-driver-toolkit
+      build_args:
+        - ARCH=arm64
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/heads/dev
+      event:
+        - push
+
+  - name: docker-build-sle-micro
+    image: plugins/docker
+    settings:
+      dockerfile: nvidia-driver-toolkit/Dockerfile
+      repo: "rancher/harvester-os"
+      tag: "nvidia-driver-toolkit-sle-micro-head-arm64"
+      context: nvidia-driver-toolkit
+      dry_run: true
+      build_args:
+        - ARCH=arm64
+    when:
+      instance:
+        - drone-pr.rancher.io
+      branch:
+        - sle-micro
+
+  - name: docker-publish-sle-micro
+    image: plugins/docker
+    settings:
+      dockerfile: nvidia-driver-toolkit/Dockerfile
+      repo: "rancher/harvester-os"
+      tag: "nvidia-driver-toolkit-sle-micro-head-arm64"
+      context: nvidia-driver-toolkit
+      build_args:
+        - ARCH=arm64
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/heads/sle-micro
+      event:
+        - push
+        - cron
+
+  - name: docker-publish
+    image: plugins/docker
+    settings:
+      dockerfile: nvidia-driver-toolkit/Dockerfile
+      repo: "rancher/harvester-os"
+      tag: "nvidia-driver-toolkit-${DRONE_TAG}-arm64"
+      context: nvidia-driver-toolkit
+      build_args:
+        - ARCH=arm64
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/tags/*
+      event:
+        - tag
+---
+kind: pipeline
+name: nvidia-driver-toolkit-manifest
+
+steps:
+  - name: push-dev-head
+    image: plugins/manifest
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      target: "rancher/harvester-os:nvidia-driver-toolkit-dev-head"
+      template: "rancher/harvester-os:nvidia-driver-toolkit-dev-head-ARCH"
+      ignore_missing: true
+      platforms:
+        - linux/amd64
+        - linux/arm64
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/heads/dev
+      event:
+        - push
+
+  - name: push-tag
+    image: plugins/manifest
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      target: "rancher/harvester-os:nvidia-driver-toolkit-${DRONE_TAG}"
+      template: "rancher/harvester-os:nvidia-driver-toolkit-${DRONE_TAG}-ARCH"
+      ignore_missing: true
+      platforms:
+        - linux/amd64
+        - linux/arm64
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/tags/*
+      event:
+        - tag
+
+  - name: push-sle-micro-head
+    image: plugins/manifest
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      target: "rancher/harvester-os:nvidia-driver-toolkit-sle-micro-head"
+      template: "rancher/harvester-os:nvidia-driver-toolkit-sle-micro-head-ARCH"
+      ignore_missing: true
+      platforms:
+        - linux/amd64
+        - linux/arm64
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/heads/sle-micro
+      event:
+        - push
+        - cron
+depends_on:
+  - nvidia-driver-toolkit-amd64
+  - nvidia-driver-toolkit-arm64

--- a/.drone.yml
+++ b/.drone.yml
@@ -293,8 +293,8 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: nvidia-driver-toolkit/Dockerfile
-      repo: "rancher/harvester-os"
-      tag: "nvidia-driver-toolkit-dev-head-amd64"
+      repo: "rancher/harvester-nvidia-driver-toolkit"
+      tag: "dev-head-amd64"
       dry_run: true
       context: nvidia-driver-toolkit
       build_args:
@@ -309,8 +309,8 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: nvidia-driver-toolkit/Dockerfile
-      repo: "rancher/harvester-os"
-      tag: "nvidia-driver-toolkit-dev-head-amd64"
+      repo: "rancher/harvester-nvidia-driver-toolkit"
+      tag: "dev-head-amd64"
       context: nvidia-driver-toolkit
       build_args:
         - ARCH=amd64
@@ -330,8 +330,8 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: nvidia-driver-toolkit/Dockerfile
-      repo: "rancher/harvester-os"
-      tag: "nvidia-driver-toolkit-sle-micro-head-amd64"
+      repo: "rancher/harvester-nvidia-driver-toolkit"
+      tag: "sle-micro-head-amd64"
       dry_run: true
       context: nvidia-driver-toolkit
       build_args:
@@ -346,8 +346,8 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: nvidia-driver-toolkit/Dockerfile
-      repo: "rancher/harvester-os"
-      tag: "nvidia-driver-toolkit-sle-micro-head-amd64"
+      repo: "rancher/harvester-nvidia-driver-toolkit"
+      tag: "sle-micro-head-amd64"
       context: nvidia-driver-toolkit
       build_args:
         - ARCH=amd64
@@ -368,8 +368,8 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: nvidia-driver-toolkit/Dockerfile
-      repo: "rancher/harvester-os"
-      tag: "nvidia-driver-toolkit-${DRONE_TAG}-amd64"
+      repo: "rancher/harvester-nvidia-driver-toolkit"
+      tag: "${DRONE_TAG}-amd64"
       context: nvidia-driver-toolkit
       build_args:
         - ARCH=amd64
@@ -397,8 +397,8 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: nvidia-driver-toolkit/Dockerfile
-      repo: "rancher/harvester-os"
-      tag: "nvidia-driver-toolkit-dev-head-arm64"
+      repo: "rancher/harvester-nvidia-driver-toolkit"
+      tag: "dev-head-arm64"
       context: nvidia-driver-toolkit
       dry_run: true
       build_args:
@@ -413,8 +413,8 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: nvidia-driver-toolkit/Dockerfile
-      repo: "rancher/harvester-os"
-      tag: "nvidia-driver-toolkit-dev-head-arm64"
+      repo: "rancher/harvester-nvidia-driver-toolkit"
+      tag: "dev-head-arm64"
       context: nvidia-driver-toolkit
       build_args:
         - ARCH=arm64
@@ -434,8 +434,8 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: nvidia-driver-toolkit/Dockerfile
-      repo: "rancher/harvester-os"
-      tag: "nvidia-driver-toolkit-sle-micro-head-arm64"
+      repo: "rancher/harvester-nvidia-driver-toolkit"
+      tag: "sle-micro-head-arm64"
       context: nvidia-driver-toolkit
       dry_run: true
       build_args:
@@ -450,8 +450,8 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: nvidia-driver-toolkit/Dockerfile
-      repo: "rancher/harvester-os"
-      tag: "nvidia-driver-toolkit-sle-micro-head-arm64"
+      repo: "rancher/harvester-nvidia-driver-toolkit"
+      tag: "sle-micro-head-arm64"
       context: nvidia-driver-toolkit
       build_args:
         - ARCH=arm64
@@ -472,8 +472,8 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: nvidia-driver-toolkit/Dockerfile
-      repo: "rancher/harvester-os"
-      tag: "nvidia-driver-toolkit-${DRONE_TAG}-arm64"
+      repo: "rancher/harvester-nvidia-driver-toolkit"
+      tag: "${DRONE_TAG}-arm64"
       context: nvidia-driver-toolkit
       build_args:
         - ARCH=arm64
@@ -500,8 +500,8 @@ steps:
         from_secret: docker_username
       password:
         from_secret: docker_password
-      target: "rancher/harvester-os:nvidia-driver-toolkit-dev-head"
-      template: "rancher/harvester-os:nvidia-driver-toolkit-dev-head-ARCH"
+      target: "rancher/harvester-nvidia-driver-toolkit:dev-head"
+      template: "rancher/harvester-nvidia-driver-toolkit:dev-head-ARCH"
       ignore_missing: true
       platforms:
         - linux/amd64
@@ -521,8 +521,8 @@ steps:
         from_secret: docker_username
       password:
         from_secret: docker_password
-      target: "rancher/harvester-os:nvidia-driver-toolkit-${DRONE_TAG}"
-      template: "rancher/harvester-os:nvidia-driver-toolkit-${DRONE_TAG}-ARCH"
+      target: "rancher/harvester-nvidia-driver-toolkit:${DRONE_TAG}"
+      template: "rancher/harvester-nvidia-driver-toolkit:${DRONE_TAG}-ARCH"
       ignore_missing: true
       platforms:
         - linux/amd64
@@ -542,8 +542,8 @@ steps:
         from_secret: docker_username
       password:
         from_secret: docker_password
-      target: "rancher/harvester-os:nvidia-driver-toolkit-sle-micro-head"
-      template: "rancher/harvester-os:nvidia-driver-toolkit-sle-micro-head-ARCH"
+      target: "rancher/harvester-nvidia-driver-toolkit:sle-micro-head"
+      template: "rancher/harvester-nvidia-driver-toolkit:sle-micro-head-ARCH"
       ignore_missing: true
       platforms:
         - linux/amd64

--- a/nvidia-driver-toolkit/Dockerfile
+++ b/nvidia-driver-toolkit/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos-headers:latest
+COPY entrypoint.sh /bin/entrypoint.sh
+ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/nvidia-driver-toolkit/entrypoint.sh
+++ b/nvidia-driver-toolkit/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+if [ -f /tmp/ready ]
+then
+  rm /tmp/ready
+fi
+
+if [ -n "${DRIVER_LOCATION}" ]
+then
+    echo "Installing nvidia driver from ${DRIVER_LOCATION}"
+    curl -o /tmp/NVIDIA.run -k $DRIVER_LOCATION
+    chmod +x /tmp/NVIDIA.run
+    /tmp/NVIDIA.run -q --ui=none --no-systemd
+else
+    echo "No DRIVER_LOCATION specified. skipping..."
+fi
+
+echo "running nvidia vgpud"
+/usr/bin/nvidia-vgpud
+/usr/bin/nvidia-vgpu-mgr
+
+echo "driver ready" > /tmp/ready
+
+tail -f /dev/null


### PR DESCRIPTION
PR introduces packaging and ci for nvidia-driver-toolkit image which is based on the `baseos-headers` image. 