### PR TITLE
added additional logic to create /dev/char directory

### DIFF
--- a/nvidia-driver-toolkit/entrypoint.sh
+++ b/nvidia-driver-toolkit/entrypoint.sh
@@ -7,6 +7,18 @@ then
   rm /tmp/ready
 fi
 
+# fix from: https://gitlab.com/nvidia/container-images/driver/-/commit/94324dc6dbaff191b72a734b7734710110d82198
+# Create /dev/char directory if it doesn't exist inside the container.
+# Without this directory, nvidia-vgpu-mgr will fail to create symlinks
+# under /dev/char for new devices nodes.
+create_dev_char_directory() {
+	if [ ! -d "/dev/char" ]; then
+		echo "Creating '/dev/char' directory"
+		mkdir -p /dev/char
+	fi
+}
+
+
 if [ -n "${DRIVER_LOCATION}" ]
 then
     echo "Installing nvidia driver from ${DRIVER_LOCATION}"
@@ -18,6 +30,7 @@ else
 fi
 
 echo "running nvidia vgpud"
+create_dev_char_directory
 /usr/bin/nvidia-vgpud
 /usr/bin/nvidia-vgpu-mgr
 


### PR DESCRIPTION
Based on feedback from the users, the newer versions of the nvidia driver need the presence of /dev/char folder. 
Without this the end users can run into errors similar to below

```
[66602.044676] [nvidia-vgpu-vfio] 54adacd7-1308-4385-8fc2-0590a4999818: start failed. status: 0x65 Timeout Occured
```
