### PR TITLE
oem: patch lvm.conf for the local path (lvm) support

### DIFF
--- a/files/system/oem/91_lvm.yaml
+++ b/files/system/oem/91_lvm.yaml
@@ -1,7 +1,13 @@
 name: "apply Harvester lvm config"
 stages:
    initramfs:
-     - name: "patch lvm config (add gloabl_filter)"
+     - name: "patch lvm config (filter out loop/longhorn device)"
        commands:
        - |
-        sed -i 's/^devices.*/&\n\tglobal_filter = [ "r|.*\/|" ]/' /etc/lvm/lvm.conf
+        sed -i 's/^devices.*/&\n\tglobal_filter = [ "r|\/dev\/loop.*|", "r|\/dev\/disk\/by-path\/.*longhorn.*|" ]/' /etc/lvm/lvm.conf
+     - name: "patch udev_sync, udev_rules on lvm config"
+       commands:
+       - |
+        sed -i 's/# udev_sync = 1/udev_sync = 0/' /etc/lvm/lvm.conf
+        sed -i 's/# udev_rules = 1/udev_rules = 0/' /etc/lvm/lvm.conf
+        sed -i 's/# auto_set_activation_skip = 1/auto_set_activation_skip = 0/' /etc/lvm/lvm.conf


### PR DESCRIPTION
    - we should only filter out the loop/longhorn device
    - udev_sync/udev_rule will deadlock the current lvcreate.
      Actually lvm did not rely on it so we could disable it.

Related issue: https://github.com/harvester/harvester/issues/5724