### PR TITLE
support for multipathd

### DIFF
--- a/files/etc/dracut.conf.d/50-elemental-initrd.conf
+++ b/files/etc/dracut.conf.d/50-elemental-initrd.conf
@@ -1,4 +1,4 @@
 hostonly_cmdline="no"
 hostonly="no"
 compress="xz"
-add_dracutmodules+=" dmsquash-live "
+add_dracutmodules+=" livenet dmsquash-live "


### PR DESCRIPTION
PR overrides the dracut config files from os2 and upstream elemental package to enable multipath.

This is needed to ensure that when multipath is enabled with external disks then OS can boot of multipath devices

related to: https://github.com/harvester/harvester/issues/5150