### PR TITLE
additional directive to add firmware search path

### DIFF
--- a/nvidia-driver-toolkit/entrypoint.sh
+++ b/nvidia-driver-toolkit/entrypoint.sh
@@ -29,6 +29,16 @@ else
     echo "No DRIVER_LOCATION specified. skipping..."
 fi
 
+# update nvidia driver firmware search path
+# /run/nvidia/driver/lib/firmware is mount under /lib/firmware in the container 
+# by the daemonset manifests
+EXISTS=$(grep '/run/nvidia/driver/lib/firmware' /sys/module/firmware_class/parameters/path)
+if [ -z "${EXISTS}" ]
+then
+    echo "Adding firmware search path to /sys/module/firmware_class/parameters/path"
+    echo  '/run/nvidia/driver/lib/firmware' > /sys/module/firmware_class/parameters/path
+fi
+
 echo "running nvidia vgpud"
 create_dev_char_directory
 /usr/bin/nvidia-vgpud


### PR DESCRIPTION
Include additional entrypoint directive to define firmware loading path for nvidia firmware

https://www.kernel.org/doc/html/v4.18/driver-api/firmware/fw_search_path.html

Related to: https://github.com/harvester/harvester/issues/6487