### PR TITLE
move datasource lookup to initramfs stage after the fs are setup

### DIFF
--- a/files/system/oem/00_rootfs.yaml
+++ b/files/system/oem/00_rootfs.yaml
@@ -1,10 +1,5 @@
 name: "Rootfs Layout Settings"
 stages:
-  rootfs.before:
-    - name: "Pull data from provider"
-      datasource:
-        providers: ["cdrom"]
-        path: "/oem"
   rootfs:
     - if: '[ ! -f "/run/cos/recovery_mode" ]'
       name: "Layout configuration"

--- a/files/system/oem/02_datasource.yaml
+++ b/files/system/oem/02_datasource.yaml
@@ -1,0 +1,7 @@
+name: "Elemental cloud-config from a removable device"
+stages:
+  initramfs:
+  - name: "Pull data from provider"
+    datasource:
+      providers: ["cdrom"]
+      path: "/oem"


### PR DESCRIPTION
Related to: https://github.com/harvester/harvester/issues/7017

datasource lookup seems to currently fail on physical machines. this seems to be related to a race condition between scsi device scan being completed and cdrom being available before the datasource lookup is performed.

moving the datasource lookup to `initramfs` stage seems to address this and also brings the datasource lookup to upstream elemental: https://github.com/rancher/elemental/blob/main/framework/files/system/oem/02_datasources.yaml