### PR TITLE
lookup cdrom datasource in rootfs.before stage

### DIFF
--- a/files/system/oem/02_datasource.yaml
+++ b/files/system/oem/02_datasource.yaml
@@ -1,5 +1,10 @@
 name: "Elemental cloud-config from a removable device"
 stages:
+  rootfs.before:
+    - name: "Pull data from provider"
+      datasource:
+        providers: ["cdrom"]
+        path: "/oem"
   initramfs:
   - name: "Pull data from provider"
     datasource:


### PR DESCRIPTION
Original PR https://github.com/harvester/os2/pull/137 seems to break the upgrade path as the userdata is never read from vm cloud-init datasource

To work around this we are adding cdrom datasource lookup in both rootfs.pre and initramfs datasource which should help handle both the upgrade path and new install scenario.

Related to: https://github.com/harvester/harvester/issues/7017