### PR TITLE
GHA: correct release github action

### DIFF
--- a/.github/workflows/installer-pr.yml
+++ b/.github/workflows/installer-pr.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: fetch-target-version
         run: |
-          run: echo "targetVersion=$(echo ${{ inputs.tag }} | cut -d'-' -f1)" >> $GITHUB_ENV
+          echo "targetVersion=$(echo ${{ inputs.tag }} | cut -d'-' -f1)" >> $GITHUB_ENV
           echo "Get targetVersion: $targetVersion"
       - name: Install docker
         run: zypper ref && zypper -n install docker
@@ -38,11 +38,7 @@ jobs:
           echo "Diff $BASE_OS_IMAGE with ${{ env.IMAGE_NAME }}..."
           container-diff diff daemon://docker.io/$BASE_OS_IMAGE daemon://docker.io/${{ env.IMAGE_NAME }} --type=rpm --output=diff-result.txt
           cat diff-result.txt
-      - name: Upload container-diff result
-        uses: actions/upload-artifact@v3
-        with:
-          name: diff-result
-          path: diff-result.txt
+          echo "packagesDiff=$(cat diff-result.txt)" >> $GITHUB_ENV
 
   create-installer-pr:
     runs-on: ubuntu-latest
@@ -90,7 +86,7 @@ jobs:
 
             **More info:**
             ```
-            $DIFF
+            $packagesDiff
             ```
 
   create-addon-pr:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     secrets: inherit
 
   create-corresponding-pull-requests:
+    needs: build-for-release
     uses: ./.github/workflows/installer-pr.yml
     with:
       tag: ${{ github.ref_name }}


### PR DESCRIPTION
    - we should wait release image
    - remove upload action, because we could complete the whole tasks at on the same time.