### PR TITLE
fix: ensure machine-id, initiatorname.iscsi and host{id,nqn} are unique

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,3 +47,8 @@ ARG NERDCTL_VERSION=1.2.1
 RUN curl -o ./nerdctl-bin.tar.gz -sfL "https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${ARCH}.tar.gz"
 RUN tar -zxvf nerdctl-bin.tar.gz && mv nerdctl /usr/bin/
 RUN rm -f nerdctl-bin.tar.gz containerd-rootless-setuptool.sh containerd-rootless.sh
+
+# Remove files that need to be unique on each host.
+# These will be generated automatically at runtime.
+# See https://github.com/harvester/harvester/issues/6911 for details
+RUN rm -f /etc/machine-id /etc/iscsi/initiatorname.iscsi /etc/nvme/hostid /etc/nvme/hostnqn

--- a/files/system/oem/00_rootfs.yaml
+++ b/files/system/oem/00_rootfs.yaml
@@ -13,6 +13,7 @@ stages:
           /etc/rancher
           /etc/ssh
           /etc/iscsi 
+          /etc/nvme
           /etc/cni
           /etc/pki/trust/anchors
           /home
@@ -50,4 +51,24 @@ stages:
         else
           mkdir -p /usr/local/etc
           cp /etc/machine-id /usr/local/etc
+        fi
+    - if: '[ ! -f "/run/cos/recovery_mode" -a -d "/etc/iscsi" ]'
+      name: "Generate /etc/iscsi/initiatorname.iscsi"
+      commands:
+      - |
+        if [ ! -f /etc/iscsi/initiatorname.iscsi ] ; then
+            /usr/bin/echo "Generating /etc/iscsi/initiatorname.iscsi"
+            /sbin/iscsi-gen-initiatorname
+        fi
+    - if: '[ ! -f "/run/cos/recovery_mode" -a -d "/etc/nvme" ]'
+      name: "Generate /etc/nvme/hostnqn and /etc/nvme/hostid"
+      commands:
+      - |
+        if [ ! -s /etc/nvme/hostnqn ]; then
+            /usr/bin/echo "Generating /etc/nvme/hostnqn"
+            /usr/sbin/nvme gen-hostnqn > /etc/nvme/hostnqn
+        fi
+        if [ ! -s /etc/nvme/hostid ]; then
+            /usr/bin/echo "Generating /etc/nvme/hostid"
+            sed -nr 's/.*:uuid:(.*?)$/\1/p' /etc/nvme/hostnqn > /etc/nvme/hostid
         fi


### PR DESCRIPTION
Our OS image includes `/etc/machine-id`, `/etc/iscsi/initiatorname.iscsi`, `/etc/nvme/hostid` and `/etc/nvme/hostnqn`.  This means that those files will be identical on every single Harvester node installed from a given ISO image.  This is wrong.

`/etc/machine-id` is meant to be unique per host, see e.g.:

https://manpages.opensuse.org/Tumbleweed/systemd/machine-id.5.en.html

Likewise, the iSCSI initiator name and NVMe hostid/hostnqn need to be unique when accessing external storage via iSCSI or NVMe over fabrics.

This commit removes those files from the OS image, and adds commands to `00_rootfs.yaml` to generate `/etc/iscsi/initiatorname.iscsi`, `/etc/nvme/hostid` and `/etc/nvme/hostnqn` at boot time, if those files don't already exist (which they won't, on first boot - after that the generated content will persist). ` /etc/machine-id` generation is handled automatically by systemd and its persistence is already covered by existing code in `00_rootfs.yaml`.

Related issue: https://github.com/harvester/harvester/issues/6911

Note that this also requires https://github.com/harvester/harvester-installer/pull/984 in order to work correctly (see that PR for the test plan).