### PR TITLE
Add libopenssl1_1-hmac for FIPS compatibility.

### DIFF
--- a/nvidia-driver-toolkit/Dockerfile
+++ b/nvidia-driver-toolkit/Dockerfile
@@ -1,3 +1,8 @@
 FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos-headers:latest
+
+RUN zypper update -y && \
+    zypper install -y libopenssl1_1-hmac
+
 COPY entrypoint.sh /bin/entrypoint.sh
+
 ENTRYPOINT ["/bin/entrypoint.sh"]


### PR DESCRIPTION
### Related Issue
https://github.com/harvester/harvester/issues/8006

### Testing

***FIPS-enabled System***
1. Install FIPS-enabled Harvester.
2. Enable `nvidia-driver-toolkit` addon.
3. Modify the addon to use the FIPS-enabled built image from this PR.
4. If not leveraging vGPU hardware, you'll need to modify the DaemonSet to remove the `nodeSelector` in order for pods to provision.
5. Check the logs of the pods and ensure there are no FIPS-related errors.

Logs should look similar to this:
```
if [[ ${KUBERNETES_SERVICE_HOST} =~ .*:.* ]]; then
	echo "KUBERNETES_SERVICE_HOST is using IPv6"
	CHART="${CHART//%\{KUBERNETES_API\}%/[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}}"
else
	CHART="${CHART//%\{KUBERNETES_API\}%/${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}}"
fi

set +v -x
+ [[ '' == \v\2 ]]
+ shopt -s nullglob
+ [[ -f /config/ca-file.pem ]]
+ [[ -f /tmp/ca-file.pem ]]
+ [[ false == \t\r\u\e ]]
+ [[ false == \t\r\u\e ]]
+ [[ -n '' ]]
+ helm_content_decode
+ set -e
+ ENC_CHART_PATH=/chart/nvidia-driver-toolkit.tgz.base64
+ CHART_PATH=/tmp/nvidia-driver-toolkit.tgz
+ [[ ! -f /chart/nvidia-driver-toolkit.tgz.base64 ]]
+ return
+ [[ install != \d\e\l\e\t\e ]]
+ helm_repo_init
+ grep -q -e 'https\?://'
+ [[ nvidia-driver-toolkit/nvidia-driver-runtime == stable/* ]]
+ [[ -n http://harvester-cluster-repo.cattle-system.svc/charts ]]
+ [[ -f /auth/username ]]
+ [[ -f /auth/tls.crt ]]
+ helm repo add nvidia-driver-toolkit http://harvester-cluster-repo.cattle-system.svc/charts
"nvidia-driver-toolkit" has been added to your repositories
+ helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "nvidia-driver-toolkit" chart repository
Update Complete. ⎈Happy Helming!⎈
+ helm_update install --version 1.5.0-dev.0
++ helm ls --all -f '^nvidia-driver-toolkit$' --namespace harvester-system --output json
++ jq -r '"\(.[0].chart),\(.[0].status)"'
++ tr '[:upper:]' '[:lower:]'
+ LINE=nvidia-driver-runtime-1.5.0-dev.0,deployed
+ IFS=,
+ read -r INSTALLED_VERSION STATUS _
+ VALUES=
+ for VALUES_FILE in /config/*.yaml
+ VALUES=' --values /config/values-01_HelmChart.yaml'
+ [[ install = \d\e\l\e\t\e ]]
+ [[ nvidia-driver-runtime-1.5.0-dev.0 =~ ^(|null)$ ]]
+ [[ deployed =~ ^(pending-install|pending-upgrade|pending-rollback|uninstalling)$ ]]
+ [[ deployed =~ ^deployed$ ]]
+ echo 'Already installed nvidia-driver-toolkit'
+ helm mapkubeapis nvidia-driver-toolkit --namespace harvester-system
Already installed nvidia-driver-toolkit
2025/04/03 22:55:35 Release 'nvidia-driver-toolkit' will be checked for deprecated or removed Kubernetes APIs and will be updated if necessary to supported API versions.
2025/04/03 22:55:35 Get release 'nvidia-driver-toolkit' latest version.
2025/04/03 22:55:35 Check release 'nvidia-driver-toolkit' for deprecated or removed APIs...
2025/04/03 22:55:35 Finished checking release 'nvidia-driver-toolkit' for deprecated or removed APIs.
2025/04/03 22:55:35 Release 'nvidia-driver-toolkit' has no deprecated or removed APIs.
2025/04/03 22:55:35 Map of release 'nvidia-driver-toolkit' deprecated or removed APIs to supported versions, completed successfully.
+ echo 'Upgrading helm chart'
Upgrading nvidia-driver-toolkit
+ echo 'Upgrading nvidia-driver-toolkit'
+ shift 1
+ helm upgrade --version 1.5.0-dev.0 nvidia-driver-toolkit nvidia-driver-toolkit/nvidia-driver-runtime --values /config/values-01_HelmChart.yaml
Release "nvidia-driver-toolkit" has been upgraded. Happy Helming!
NAME: nvidia-driver-toolkit
LAST DEPLOYED: Thu Apr  3 22:55:35 2025
NAMESPACE: harvester-system
STATUS: deployed
REVISION: 2
TEST SUITE: None
+ exit
```

***Non-FIPS Enable System***

Perform the above steps on a non-FIPS system to ensure backwards compatibility.

### Notes
* We can provide access to a FIPS-enabled ISO for testing. Please reach out.
* We're not sure exactly how the OBS build system works with SCC entitlements in order to have access to install the given package. We looked at a few places and it seemed like it "just worked", but OBS is a bit of a blackbox for us.

