### PR TITLE
chore: update baseos to use v1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos:latest AS base
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.6/main/baseos:latest AS base
 
 ARG CACHEBUST
 

--- a/nvidia-driver-toolkit/Dockerfile
+++ b/nvidia-driver-toolkit/Dockerfile
@@ -1,3 +1,7 @@
-FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos-headers:latest
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.6/main/baseos-headers:latest
+
+RUN zypper update -y && \
+    zypper install -y libopenssl1_1-hmac
+
 COPY entrypoint.sh /bin/entrypoint.sh
 ENTRYPOINT ["/bin/entrypoint.sh"]


### PR DESCRIPTION
Bump baseos to use v1.6 artifacts for the v1.6 stable branch.
