### PR TITLE
gha: dev.yml: Add workflow_dispatch to allow manual build & publish

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,6 +7,7 @@ on:
     - sl-micro-6
   schedule:
     - cron: "0 1 * * *"
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
This adds a "Run workflow" button to github actions for this workflow which will allow re-triggering the dev (sle-micro) build and publish manually, i.e. outside the regular daily schedule.  One this is merged, if I then cherry-pick this commit to the sl-micro-6 branch, I should be able to use this to manually build and publish _that_ branch as needed for development purposes.