### PR TITLE
feat: fetch specific node annotation to install nvidia driver

### DIFF
--- a/nvidia-driver-toolkit/Dockerfile
+++ b/nvidia-driver-toolkit/Dockerfile
@@ -1,3 +1,9 @@
 FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos-headers:latest
+
+ARG TARGETARCH
+RUN curl -kLO "https://dl.k8s.io/release/$(curl -k -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+    && rm kubectl
+
 COPY entrypoint.sh /bin/entrypoint.sh
 ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/nvidia-driver-toolkit/entrypoint.sh
+++ b/nvidia-driver-toolkit/entrypoint.sh
@@ -18,16 +18,38 @@ create_dev_char_directory() {
 	fi
 }
 
+install_nvidia_driver() {
+    local driver_location="$1"
+    
+    if [ -n "$driver_location" ]; then
+        echo "Installing nvidia driver from $driver_location"
+        curl -o /tmp/NVIDIA.run -k "$driver_location"
+        chmod +x /tmp/NVIDIA.run
+        /tmp/NVIDIA.run -q --ui=none --no-systemd
+    else
+        echo "No driver location specified. Skipping driver installation..."
+    fi
+}
 
-if [ -n "${DRIVER_LOCATION}" ]
-then
-    echo "Installing nvidia driver from ${DRIVER_LOCATION}"
-    curl -o /tmp/NVIDIA.run -k $DRIVER_LOCATION
-    chmod +x /tmp/NVIDIA.run
-    /tmp/NVIDIA.run -q --ui=none --no-systemd
-else
-    echo "No DRIVER_LOCATION specified. skipping..."
-fi
+get_nvidia_driver_version() {
+  local driver_location="$DRIVER_LOCATION"  # Default driver location
+  local annotation_key="sriovgpu.harvesterhci.io/custom-driver"
+  local node_name="$NODE_NAME"
+  local custom_driver=$(kubectl get node "$node_name" -o json | jq -r ".metadata.annotations[\"$annotation_key\"] // empty")
+
+  if [ -n "$custom_driver" ]; then
+    echo >&2 "Found custom driver annotation: $annotation_key=$custom_driver"
+    driver_location="$custom_driver"
+  else
+    echo >&2 "No custom driver annotation found. Using default driver location."
+  fi
+
+  echo $driver_location
+}
+
+driver_location=$(get_nvidia_driver_version)
+echo "Driver location: $driver_location"
+install_nvidia_driver "$driver_location"
 
 echo "running nvidia vgpud"
 create_dev_char_directory


### PR DESCRIPTION
#### Problem:
Users have multiple GPU types spread across the nodes, users may need a different driver to be installed on specific node.

#### Solution:
User should be able to install specific the driver on a per node by reading node annotation.

#### Related Issue(s):
harvester/harvester#8338

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

Label doesn't support a URL.

```
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
# nodes "harvester1" was not valid:
# * metadata.labels: Invalid value: "https://google.com/NVIDIA-Linux-x86_64-vgpu-kvm.run":     a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.    ', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',      or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
# * metadata.labels: Invalid value: "https://google.com/NVIDIA-Linux-x86_64-vgpu-kvm.run":     a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.    ', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',      or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
# * metadata.labels: Invalid value: "https://google.com/NVIDIA-Linux-x86_64-vgpu-kvm.run":     a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.    ', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',      or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
# * metadata.labels: Invalid value: "https://google.com/NVIDIA-Linux-x86_64-vgpu-kvm.run":     a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.    ', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',      or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
#
```
