### PR TITLE
feat: add NetworkManager configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,3 +52,12 @@ RUN rm -f nerdctl-bin.tar.gz containerd-rootless-setuptool.sh containerd-rootles
 # These will be generated automatically at runtime.
 # See https://github.com/harvester/harvester/issues/6911 for details
 RUN rm -f /etc/machine-id /etc/iscsi/initiatorname.iscsi /etc/nvme/hostid /etc/nvme/hostnqn
+
+# NetworkManager should already be enabled by default when it's installed,
+# but adding it here anyway to make it explicit.  NetworkManager-dispatcher
+# is also enabled, even though we're not currently taking advantage of any
+# dispatcher scripts, but rather just to get rid of a whole lot of annoying
+# errors in the journal along the lines of "Activation via systemd failed
+# for unit 'dbus-org.freedesktop.nm-dispatcher.service'")
+RUN systemctl enable NetworkManager.service && \
+    systemctl enable NetworkManager-dispatcher.service

--- a/files/etc/NetworkManager/conf.d/harvester.conf
+++ b/files/etc/NetworkManager/conf.d/harvester.conf
@@ -1,0 +1,8 @@
+[main]
+# Don't do automatic DHCP configuration of ethernet devices
+# without connection profiles
+no-auto-default=*
+
+# Ignore carrier (cable plugged in) when attempting to
+# activate static IP connections
+ignore-carrier=*

--- a/files/etc/dracut.conf.d/60-generate-ifcfg.conf
+++ b/files/etc/dracut.conf.d/60-generate-ifcfg.conf
@@ -1,2 +1,2 @@
-# This is required for Dracut to generate ifcfg files from "ip=..." kernel cmdline args
-add_dracutmodules+=" ifcfg "
+# This is required for Dracut to generate networkmanager config from "ip=..." kernel cmdline args
+add_dracutmodules+=" network-manager "

--- a/files/system/oem/00_rootfs.yaml
+++ b/files/system/oem/00_rootfs.yaml
@@ -23,7 +23,7 @@ stages:
           /var/log
           /var/lib/rancher
           /var/lib/kubelet
-          /var/lib/wicked
+          /var/lib/NetworkManager
           /var/lib/longhorn
           /var/lib/cni
           /var/crash

--- a/files/system/oem/92_iso_repo.yaml
+++ b/files/system/oem/92_iso_repo.yaml
@@ -10,11 +10,10 @@ stages:
         permissions: 0664
       commands:
       - |
-        for i in /sys/class/net/{eth*,en*,ib*}; do
-          [ -e $i ] || continue
-          if_cfg="/etc/sysconfig/network/ifcfg-$(basename $i)"
-          echo "BOOTPROTO=dhcp" > $if_cfg
-          echo "STARTMODE=onboot" >> $if_cfg
-        done
+        # Let NetworkManager bring up all connected interfaces with DHCP
+        # automatically for the ISO repo
+        if [ -e /etc/NetworkManager/conf.d/harvester.conf ] ; then
+          sed -i '/^no-auto-default=\*/d' /etc/NetworkManager/conf.d/harvester.conf
+        fi
       - cp /etc/nginx/conf.d/iso.conf.disabled /etc/nginx/conf.d/iso.conf
       - systemctl enable nginx


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
Need to migrate from Wicked to NetworkManager

#### Solution:
This PR adds necessary changes to the base operating system image.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/3418

#### Test plan:
TBD

#### Additional documentation or context

This should be reviewed in conjunction with https://github.com/harvester/harvester-installer/pull/1141.

Note that this PR relies on registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos:latest being updated to include NetworkManager, and not include wicked. For the sake of test/review purposes, right now, there's an additional commit to use registry.opensuse.org/home/tserong/branches/isv/rancher/harvester/os/dev/main/baseos:latest instead. Once this PR passes review, we'll need to drop that commit before merging.