### PR TITLE
chore: update baseos to use v1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos:latest AS base
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.7/main/baseos:v1.7 AS base
 
 ARG CACHEBUST
 

--- a/nvidia-driver-toolkit/Dockerfile
+++ b/nvidia-driver-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos-headers:latest
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.7/main/baseos-headers:v1.7
 
 ARG TARGETARCH
 RUN curl -kLO "https://dl.k8s.io/release/$(curl -k -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" \


### PR DESCRIPTION
Bump baseos to use v1.7 artifacts for the v1.7 stable branch.
