### PR TITLE
fix: Add /var/lib/wicked back to persistent paths

### DIFF
--- a/files/system/oem/00_rootfs.yaml
+++ b/files/system/oem/00_rootfs.yaml
@@ -23,6 +23,7 @@ stages:
           /var/log
           /var/lib/rancher
           /var/lib/kubelet
+          /var/lib/wicked
           /var/lib/NetworkManager
           /var/lib/longhorn
           /var/lib/cni


### PR DESCRIPTION
#### Problem:
We previously removed `/var/lib/wicked` from the list of persistent paths...

#### Solution:
...but we're adding it back here for the sake of consistency, because systems upgraded from v1.6.x to v1.7.x will still have `/var/lib/wicked` in their list of persistent paths, thanks to a "Rootfs layout override" stage in `/oem/90_custom.yaml`.  It's safest to keep `/var/lib/wicked` in all the lists of persistent paths, in case we do ever need any old config from in there on upgraded systems.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9298

#### Test plan:
Install Harvester the check to ensure `PERSISTENT_STATE_PATHS` includes both `/var/lib/wicked` and `/var/lib/NetworkManager`, and that both are mounted correctly:

```
# cat /run/cos/cos-layout.env 
OVERLAY="tmpfs:25%"
PERSISTENT_STATE_BIND="true"
PERSISTENT_STATE_PATHS="/etc/systemd /etc/rancher /etc/ssh /etc/iscsi /etc/nvme /etc/cni /etc/pki/trust/anchors /home /opt /root /usr/libexec /var/log /var/lib/rancher /var/lib/kubelet /var/lib/wicked /var/lib/NetworkManager /var/lib/cni /var/lib/third-party /var/crash /var/lib/longhorn"
RW_PATHS="/var /etc /srv /boot /lib/firmware"
VOLUMES="LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local LABEL=HARV_LH_DEFAULT:/var/lib/harvester/defaultdisk"

# grep 'wicked\|NetworkManager' /etc/fstab
/usr/local/.state/var-lib-wicked.bind /var/lib/wicked none defaults,bind 0 0
/usr/local/.state/var-lib-NetworkManager.bind /var/lib/NetworkManager none defaults,bind 0 0

# mount|grep 'wicked\|NetworkManager'
/dev/vda5 on /var/lib/wicked type ext4 (rw,relatime,seclabel)
/dev/vda5 on /var/lib/NetworkManager type ext4 (rw,relatime,seclabel)
```

#### Additional documentation or context
See also https://github.com/harvester/harvester/pull/9476