### PR TITLE
fix: update sshd config for SL Micro 6.1

### DIFF
--- a/files/etc/ssh/sshd_config.d/harvester.conf
+++ b/files/etc/ssh/sshd_config.d/harvester.conf
@@ -1,0 +1,7 @@
+PermitRootLogin no
+LoginGraceTime 60
+AllowGroups admin
+AllowAgentForwarding no
+X11Forwarding no
+AllowTcpForwarding no
+MaxAuthTries 3

--- a/files/system/oem/09_sshd.yaml
+++ b/files/system/oem/09_sshd.yaml
@@ -1,29 +1,13 @@
 name: "apply Harvester sshd_config"
 stages:
    initramfs:
-     - name: "clear original config"
+     - name: "remove SL Micro 5.x ssh and sshd config"
        commands:
        - |
-         sed -i '/### Harvester Config/,$d' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*PermitRootLogin.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*LoginGraceTime.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*AllowGroups.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*AllowAgentForwarding.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*X11Forwarding.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*AllowTcpForwarding.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*MaxAuthTries.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*Subsystem.*sftp\)/#\1/' /etc/ssh/sshd_config
-     - name: "append config"
-       commands:
-       - |
-         cat <<EOF >> /etc/ssh/sshd_config
-         ### Harvester Config
-         PermitRootLogin no
-         LoginGraceTime 60
-         AllowGroups admin
-         AllowAgentForwarding no
-         X11Forwarding no
-         AllowTcpForwarding no
-         MaxAuthTries 3
-         Include /etc/ssh/sshd_config.d/*.conf
-         EOF
+         # remove config files that will be here on systems
+         # upgrade from Harvester before v1.7.0, which would
+         # otherwise completely override the system default
+         # config file /usr/etc/ssh/sshd_config
+         rm -f /etc/ssh/sshd_config
+         # same for /usr/etc/ssh/ssh_config
+         rm -f /etc/ssh/ssh_config


### PR DESCRIPTION
#### Problem:
SL Micro 6.1 has its default sshd config in `/usr/etc/ssh/sshd_config`, versus SLE Micro 5.5 which had it in `/etc/ssh/sshd_config`.  Previous versions of Harvester would append config to that latter file, meaning we got the combination of the system defaults plus harvester's config. Since SL Micro 6.1 moved its config to `/usr/etc/ssh/sshd_config`, Harvester's defaults effectively created a new `/etc/ssh/sshd_config` file, which completely overrode the system defaults.

#### Solution:
This commit moves the harvester ssh config to `/etc/ssh/sshd_config.d/harvester.conf` so that it will be picked up automatically by default on SL Micro 6.1, and also explicitly removes `/etc/ssh/sshd_config` in case that file is still present from old systems upgraded from SLE Micro 5.5.  This means that both freshly installed systems, and upgraded systems, will pick up the correct system defaults for sshd config, plus Harvester's configuration.

#### Related Issue(s):
Related-to: https://github.com/harvester/harvester/issues/9510

#### Test plan:
- Do a new harvester install with this fix applied. Verify there is no `/etc/ssh/sshd_config` file, that Harvester's config exists in `/etc/ssh/sshd_config.d/harvester.conf` and that if you run `sshd -T |grep usepam` as root, you see `usepam yes` (this means it's correctly picking up the system default usepam setting from `/usr/etc/ssh/sshd_config`).
- Do an upgrade from v1.6, and repeat the same verification steps as above for a new install.
