### PR TITLE
feat: add /etc/NetworkManager to persistent paths

### DIFF
--- a/files/system/oem/00_rootfs.yaml
+++ b/files/system/oem/00_rootfs.yaml
@@ -9,6 +9,7 @@ stages:
         OVERLAY: "tmpfs:25%"
         RW_PATHS: "/var /etc /srv /boot"
         PERSISTENT_STATE_PATHS: >-
+          /etc/NetworkManager
           /etc/systemd
           /etc/rancher
           /etc/ssh


### PR DESCRIPTION
#### Problem:
Need to add /etc/NetworkManager to persistent paths

#### Solution:
This PR

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9581

#### Test plan:
N/A

#### Additional documentation or context
