### PR TITLE
fix: add /etc/NetworkManager/conf.d/rke2-canal.conf

### DIFF
--- a/files/etc/NetworkManager/conf.d/rke2-canal.conf
+++ b/files/etc/NetworkManager/conf.d/rke2-canal.conf
@@ -1,0 +1,2 @@
+[keyfile]
+unmanaged-devices=interface-name:flannel*;interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali


### PR DESCRIPTION
#### Problem:
The RKE2 docs say that it's highly recommended to add this file when using NetworkManager in order to avoid having NetworkManager potentially interfere with CNI routing.  For details see
https://docs.rke2.io/known_issues#networkmanager

#### Solution:
Add `/etc/NetworkManager/conf.d/rke2-canal.conf` as specified in the RKE2 docs.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9684

#### Test plan:
Without this fix, on a running harvester node:
```
# nmcli c
NAME               UUID                                  TYPE      DEVICE       
bridge-mgmt        713373f6-bf9d-3ee3-abb2-5f295bd18145  bridge    mgmt-br      
lo                 c0f7bd54-feaf-4d0c-ac0b-6300c4c9e993  loopback  lo           
flannel.1          72846789-be1e-4f7b-b965-ac2bdd518a74  vxlan     flannel.1    
vip-0303b1fd       2b170458-d8db-4bf7-adc5-e4b02af21f09  macvlan   vip-0303b1fd 
bond-mgmt          48589773-cb7d-38c5-b579-7dd119af73b6  bond      mgmt-bo      
bond-slave-enp1s0  97ed9ced-a5cc-306a-b37c-8a6a1e6f0ad8  ethernet  enp1s0       

# nmcli d
DEVICE           TYPE      STATE                   CONNECTION        
mgmt-br          bridge    connected               bridge-mgmt       
lo               loopback  connected (externally)  lo                
vip-0303b1fd     macvlan   connected (externally)  vip-0303b1fd      
flannel.1        vxlan     connected (externally)  flannel.1         
mgmt-bo          bond      connected               bond-mgmt         
enp1s0           ethernet  connected               bond-slave-enp1s0 
cali01f15a030a1  ethernet  unmanaged               --                
cali06ad55c6b79  ethernet  unmanaged               --                
[...many more cali devices here...]
```

With this fix, on a running harvester node:
```
# nmcli c
NAME               UUID                                  TYPE      DEVICE       
bridge-mgmt        713373f6-bf9d-3ee3-abb2-5f295bd18145  bridge    mgmt-br      
lo                 a02aaa5d-10cb-4358-9940-20580c7dc427  loopback  lo           
vip-0303b1fd       d82268f1-7215-40ed-90ae-3b02e47ae801  macvlan   vip-0303b1fd 
bond-mgmt          48589773-cb7d-38c5-b579-7dd119af73b6  bond      mgmt-bo      
bond-slave-enp1s0  97ed9ced-a5cc-306a-b37c-8a6a1e6f0ad8  ethernet  enp1s0       

# nmcli d
DEVICE           TYPE      STATE                   CONNECTION        
mgmt-br          bridge    connected               bridge-mgmt       
lo               loopback  connected (externally)  lo                
vip-0303b1fd     macvlan   connected (externally)  vip-0303b1fd      
mgmt-bo          bond      connected               bond-mgmt         
enp1s0           ethernet  connected               bond-slave-enp1s0 
cali01f15a030a1  ethernet  unmanaged               --                
cali06ad55c6b79  ethernet  unmanaged               --                
[...many more cali devices here...]
veth263f0ffd     ethernet  unmanaged               --                
flannel.1        vxlan     unmanaged               --     
```

Note that with this fix, `flannel.1` is gone from from the list of connections, and the connected devices, and instead shows as `unmanaged`. Also, `veth*` now appears as `unmanaged`.

#### Additional documentation or context
See https://github.com/harvester/harvester/issues/9684#issuecomment-3658564978 for an attempt at some history 