### PR TITLE
fix: remove execute permissions from elemental systemd unit files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ARG CACHEBUST
 # elemental init first
 RUN elemental init --force
 
+# Fix https://github.com/harvester/harvester/issues/5945
+RUN chmod 644 /usr/lib/systemd/system/elemental*{service,timer} /usr/lib/dracut/modules.d/*elemental*/*service
+
 # Create the folder for journald persistent data
 RUN mkdir -p /var/log/journal
 


### PR DESCRIPTION
#### Problem:
When `elemental init` is run, all the files it installs are set to mode 755, but systemd doesn't like it when systemd unit files have execute permissions.

#### Solution:
This was fixed in elemental-toolkit v2.x by embedding tarballs inside the elemental executable, so that file permissions could be preserved.  IMO this change is non-trivial to backport to elemental-toolkit v1.1.7 as used by Harvester, so instead we're just going to `chmod` those files to set the permissions correctly right after running `elemental init`.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/5945

#### Test plan:
- Install Harvester with this fix applied
- Log in via ssh and check the journal. You should _not_ see any of the "Configuration file /usr/lib/systemd/system/elemental[...] is marked executable. Please remove executable permission bits. Proceeding anyway" errors mentioned in the related issue. `journalctl|grep 'elemental.*permission'` should do the trick.

#### Additional documentation or context
