### PR TITLE
feat: Include more cloud-init datasources

### DIFF
--- a/files/system/oem/02_datasource.yaml
+++ b/files/system/oem/02_datasource.yaml
@@ -3,10 +3,10 @@ stages:
   rootfs.before:
     - name: "Pull data from provider"
       datasource:
-        providers: ["aws", "gcp", "openstack", "cdrom", "configdrive"]
+        providers: ["aws", "gcp", "openstack", "cdrom", "config-drive"]
         path: "/oem"
   initramfs:
   - name: "Pull data from provider"
     datasource:
-      providers: ["aws", "gcp", "openstack", "cdrom", "configdrive"]
+      providers: ["aws", "gcp", "openstack", "cdrom", "config-drive"]
       path: "/oem"

--- a/files/system/oem/02_datasource.yaml
+++ b/files/system/oem/02_datasource.yaml
@@ -3,10 +3,10 @@ stages:
   rootfs.before:
     - name: "Pull data from provider"
       datasource:
-        providers: ["cdrom"]
+        providers: ["aws", "gcp", "openstack", "cdrom", "configdrive"]
         path: "/oem"
   initramfs:
   - name: "Pull data from provider"
     datasource:
-      providers: ["cdrom"]
+      providers: ["aws", "gcp", "openstack", "cdrom", "configdrive"]
       path: "/oem"


### PR DESCRIPTION
#### Problem:
Harvester doesn't allow customizations via cloud-init using config drive for example, only cdrom according to https://github.com/harvester/os2/blob/sle-micro/files/system/oem/02_datasource.yaml#L6

#### Solution:
Add more datasources.

#### Related Issue(s):
Issue harvester/harvester#9878

#### Test plan:
N/A

#### Additional documentation or context
I didn't tested it TBH.