### PR TITLE
added support for config-drive and openstack datasources

### DIFF
--- a/files/system/oem/02_datasource.yaml
+++ b/files/system/oem/02_datasource.yaml
@@ -3,10 +3,10 @@ stages:
   rootfs.before:
     - name: "Pull data from provider"
       datasource:
-        providers: ["cdrom"]
+        providers: ["cdrom","config-drive","openstack"]
         path: "/oem"
   initramfs:
   - name: "Pull data from provider"
     datasource:
-      providers: ["cdrom"]
+      providers: ["cdrom","config-drive","openstack"]
       path: "/oem"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Users are trying to install harvester via ironic and leveraging the preinstalled harvester images.

This currently fails as config-drive is not mounted under /oem and used by installer to trigger harvester configuration

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Enable `config-drive` and `openstack` datasources in harvester os

maps to https://github.com/mudler/yip/blob/master/pkg/plugins/datasource.go#L58
and https://github.com/mudler/yip/blob/master/pkg/plugins/datasource.go#L74
#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9943
#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
