### PR TITLE
fix: make LVM ignore /dev/mapper/pvc-*

### DIFF
--- a/files/system/oem/91_lvm.yaml
+++ b/files/system/oem/91_lvm.yaml
@@ -4,7 +4,7 @@ stages:
      - name: "patch lvm config (filter out loop/longhorn device)"
        commands:
        - |
-        sed -i 's/^devices.*/&\n\tglobal_filter = [ "r|\/dev\/loop.*|", "r|\/dev\/disk\/by-path\/.*longhorn.*|" ]/' /etc/lvm/lvm.conf
+        sed -i 's/^devices.*/&\n\tglobal_filter = [ "r|\/dev\/loop.*|", "r|\/dev\/disk\/by-path\/.*longhorn.*|", "r|\/dev\/mapper\/pvc-.*|" ]/' /etc/lvm/lvm.conf
      - name: "patch udev_sync, udev_rules on lvm config"
        commands:
        - |


### PR DESCRIPTION
#### Problem:
When using encrypted Longhorn volumes, these are opened on the host and end up managed by device mapper.  If the encrypted volume contains an LVM volume, this volume get set to active on the _host_, except we only actually want it to be active inside the VM guest.  Having it active on the host is wrong, and also causes trouble when you try to put the host into maintenance mode - the LVM volume being active on the host prevents the longhorn instance manager from stopping.

#### Solution:
We can fix this by adding `/dev/mapper/pvc-*` to the list of paths LVM ignores on the host.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8894

#### Test plan:
Reproduce the problem on a Harvester system _without_ this fix in place:
1. Create a VM with an additional disk, which is an encrypted longhorn volume.
2. Log in to the VM, become root, and create an LVM volume on the encrypted disk. Assuming it's `/dev/vdb`, do this:
   ```
   # pvcreate /dev/vdb
     Physical volume "/dev/vdb" successfully created.
   # vgcreate vm_vg /dev/vdb
     Volume group "vm_vg" successfully created
   # lvcreate -n vm_lv -l 100%FREE vm_vg
     Logical volume "vm_lv" created.
   
   # vgs
     VG    #PV #LV #SN Attr   VSize VFree
     vm_vg   1   1   0 wz--n- 1.98g    0 
   # lvs
     LV    VG    Attr       LSize Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
     vm_lv vm_vg -wi-a----- 1.98g
   ```
   You can go on to create a filesystem and mount it etc. if you like, but the above is sufficient to demonstrate the problem.
3. Stop the VM. Once it's stopped, start it again. This is necessary to ensure the problem manifests completely on the host.
4. Now check the host. You should see the LVM volume that was created inside the VM, on the host:
   ```
   harvester-node-1:~ # lsblk
   NAME                                       MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS
   [...]
   sda                                          8:0    0     2G  0 disk  
   └─pvc-08859731-444d-412c-b03a-0ea4edc87cac 254:0    0     2G  0 crypt 
     └─vm_vg-vm_lv                            254:1    0     2G  0 lvm   
   [...]
 
   harvester-node-1:~ # vgs
   VG    #PV #LV #SN Attr   VSize   VFree  
   vm_vg   1   1   0 wz--n-   1.98g      0 
 
   harvester-node-1:~ # lvs
   LV    VG    Attr       LSize Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
   vm_lv vm_vg -wi-a----- 1.98g                                                    
   ```

Then, on a Harvester system _with_ this fix in place, repeat the above steps. When you check the host in step 4, you should still see the encrypted pvc in the `lsblk` output, but you should not see `vm_vg-vm_lv` underneath it, nor should you see any output from the `vgs` and `lvs` command:

```
harvester-node-1:~ # lsblk
[...]
sda                                          8:0    0     2G  0 disk  
└─pvc-08859731-444d-412c-b03a-0ea4edc87cac 254:0    0     2G  0 crypt 
[...]

harvester-node-1:~ # vgs
  (there should be no output here)
harvester-node-1:~ # lvs
  (there should be no output here)
```
