### PR TITLE
Make sl-micro-6 branch use SL Micro 6.2 baseos from OBS

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -6,6 +6,7 @@ on:
     - cron: "0 5 * * *"
 
 env:
+  OS_IMAGE_v1_7_x: registry.opensuse.org/isv/rancher/harvester/os/v1.7/main/baseos:latest
   OS_IMAGE_v1_6_x: registry.opensuse.org/isv/rancher/harvester/os/v1.6/main/baseos:latest
   OS_IMAGE_v1_5_x: registry.opensuse.org/isv/rancher/harvester/os/v1.5/main/baseos:latest
   OS_IMAGE_v1_4_x: registry.opensuse.org/isv/rancher/harvester/os/v1.4/main/baseos:latest
@@ -14,6 +15,7 @@ jobs:
   get-all-releases:
     runs-on: ubuntu-latest
     outputs:
+      releaseName_v1_7_x: ${{ steps.get_release_v1_7_x.outputs.releaseName }}
       releaseName_v1_6_x: ${{ steps.get_release_v1_6_x.outputs.releaseName }}
       releaseName_v1_5_x: ${{ steps.get_release_v1_5_x.outputs.releaseName }}
       releaseName_v1_4_x: ${{ steps.get_release_v1_4_x.outputs.releaseName }}
@@ -32,6 +34,19 @@ jobs:
             
             const releases = response.data;
             core.setOutput('allReleases', releases);
+      - name: Get v1.7 latest release
+        id: get_release_v1_7_x
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const releases = ${{ steps.get_all_releases.outputs.allReleases }};
+            const releaseNamePrefix = "v1.7";
+            const foundRelease = releases.find(release => release.name.startsWith(releaseNamePrefix));
+
+            if (foundRelease) {
+              const releaseName = foundRelease.name;
+              core.setOutput('releaseName', releaseName);
+            }
       - name: Get v1.6 latest release
         id: get_release_v1_6_x
         uses: actions/github-script@v6
@@ -71,6 +86,36 @@ jobs:
               const releaseName = foundRelease.name;
               core.setOutput('releaseName', releaseName);
             }
+
+  fetch-v1-7-x-diff:
+    needs: get-all-releases
+    runs-on: ubuntu-latest
+    container:
+      image: registry.suse.com/bci/bci-base:15.5
+
+    steps:
+      - name: Set osImage
+        id: set_os_image
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const osImage = `rancher/harvester-os:${{ needs.get-all-releases.outputs.releaseName_v1_7_x }}`;
+            core.setOutput('osImage', osImage);
+      - name: Install docker
+        run: zypper ref && zypper -n install docker
+      - name: Install container-diff
+        run: |
+          curl -sfL https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -o /usr/bin/container-diff
+          chmod +x /usr/bin/container-diff
+      - name: Pull release image
+        run: |
+          docker pull ${{ steps.set_os_image.outputs.osImage }}
+      - name: Run container-diff for v1.7.x
+        run: |
+          docker pull ${{ env.OS_IMAGE_v1_7_x }}
+          echo "Diff ${{ env.OS_IMAGE_v1_7_x }} with ${{ steps.set_os_image.outputs.osImage }}..."
+          container-diff diff daemon://docker.io/${{ steps.set_os_image.outputs.osImage }} daemon://docker.io/${{ env.OS_IMAGE_v1_7_x }} --type=rpm --output=diff-result.txt
+          cat diff-result.txt
 
   fetch-v1-6-x-diff:
     needs: get-all-releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/a
 ENV ARCH=${TARGETPLATFORM#linux/}
 
 # Download rancherd
-ARG RANCHERD_VERSION=v0.7.0-rc1
+ARG RANCHERD_VERSION=v0.7.0-rc2
 RUN curl -o /usr/bin/rancherd -sfL "https://github.com/harvester/rancherd/releases/download/${RANCHERD_VERSION}/rancherd-${ARCH}" && chmod 0755 /usr/bin/rancherd
 
 # Download nerdctl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM registry.opensuse.org/isv/rancher/harvester/os/sl-micro-6.1/main/baseos:latest AS base
+FROM registry.opensuse.org/isv/rancher/harvester/os/sl-micro-6.2/main/baseos:latest AS base
 
 ARG CACHEBUST
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ARG CACHEBUST
 # elemental init first
 RUN elemental init --force
 
+# Fix https://github.com/harvester/harvester/issues/5945
+RUN chmod 644 /usr/lib/systemd/system/elemental*{service,timer} /usr/lib/dracut/modules.d/*elemental*/*service
+
 # Create the folder for journald persistent data
 RUN mkdir -p /var/log/journal
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The base OS for Harvester, powered by cOS-toolkit.
 
 Mostly we will develop on the *sle-micro* branch and backport what we needed to the stable branch.
 
+There is a sl-micro-6 branch, but this was only temporary for staging purposes when migrating from
+SLE Micro 5.5 to SL Micro 6.1, and is not part of our normal workflow.
+
 # How-Tos
 
 ## Update luet repository

--- a/files/etc/NetworkManager/conf.d/rke2-canal.conf
+++ b/files/etc/NetworkManager/conf.d/rke2-canal.conf
@@ -1,0 +1,2 @@
+[keyfile]
+unmanaged-devices=interface-name:flannel*;interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali

--- a/files/etc/ssh/sshd_config.d/harvester.conf
+++ b/files/etc/ssh/sshd_config.d/harvester.conf
@@ -1,0 +1,7 @@
+PermitRootLogin no
+LoginGraceTime 60
+AllowGroups admin
+AllowAgentForwarding no
+X11Forwarding no
+AllowTcpForwarding no
+MaxAuthTries 3

--- a/files/system/oem/00_rootfs.yaml
+++ b/files/system/oem/00_rootfs.yaml
@@ -9,6 +9,7 @@ stages:
         OVERLAY: "tmpfs:25%"
         RW_PATHS: "/var /etc /srv /boot"
         PERSISTENT_STATE_PATHS: >-
+          /etc/NetworkManager
           /etc/systemd
           /etc/rancher
           /etc/ssh

--- a/files/system/oem/00_rootfs.yaml
+++ b/files/system/oem/00_rootfs.yaml
@@ -23,6 +23,7 @@ stages:
           /var/log
           /var/lib/rancher
           /var/lib/kubelet
+          /var/lib/wicked
           /var/lib/NetworkManager
           /var/lib/longhorn
           /var/lib/cni

--- a/files/system/oem/02_datasource.yaml
+++ b/files/system/oem/02_datasource.yaml
@@ -3,10 +3,10 @@ stages:
   rootfs.before:
     - name: "Pull data from provider"
       datasource:
-        providers: ["cdrom"]
+        providers: ["cdrom","config-drive","openstack"]
         path: "/oem"
   initramfs:
   - name: "Pull data from provider"
     datasource:
-      providers: ["cdrom"]
+      providers: ["cdrom","config-drive","openstack"]
       path: "/oem"

--- a/files/system/oem/09_sshd.yaml
+++ b/files/system/oem/09_sshd.yaml
@@ -1,29 +1,13 @@
 name: "apply Harvester sshd_config"
 stages:
    initramfs:
-     - name: "clear original config"
+     - name: "remove SL Micro 5.x ssh and sshd config"
        commands:
        - |
-         sed -i '/### Harvester Config/,$d' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*PermitRootLogin.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*LoginGraceTime.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*AllowGroups.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*AllowAgentForwarding.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*X11Forwarding.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*AllowTcpForwarding.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*MaxAuthTries.*\)/#\1/' /etc/ssh/sshd_config
-         sed -i 's/^\([^#]*Subsystem.*sftp\)/#\1/' /etc/ssh/sshd_config
-     - name: "append config"
-       commands:
-       - |
-         cat <<EOF >> /etc/ssh/sshd_config
-         ### Harvester Config
-         PermitRootLogin no
-         LoginGraceTime 60
-         AllowGroups admin
-         AllowAgentForwarding no
-         X11Forwarding no
-         AllowTcpForwarding no
-         MaxAuthTries 3
-         Include /etc/ssh/sshd_config.d/*.conf
-         EOF
+         # remove config files that will be here on systems
+         # upgrade from Harvester before v1.7.0, which would
+         # otherwise completely override the system default
+         # config file /usr/etc/ssh/sshd_config
+         rm -f /etc/ssh/sshd_config
+         # same for /usr/etc/ssh/ssh_config
+         rm -f /etc/ssh/ssh_config

--- a/files/system/oem/91_lvm.yaml
+++ b/files/system/oem/91_lvm.yaml
@@ -4,7 +4,7 @@ stages:
      - name: "patch lvm config (filter out loop/longhorn device)"
        commands:
        - |
-        sed -i 's/^devices.*/&\n\tglobal_filter = [ "r|\/dev\/loop.*|", "r|\/dev\/disk\/by-path\/.*longhorn.*|" ]/' /etc/lvm/lvm.conf
+        sed -i 's/^devices.*/&\n\tglobal_filter = [ "r|\/dev\/loop.*|", "r|\/dev\/disk\/by-path\/.*longhorn.*|", "r|\/dev\/mapper\/pvc-.*|" ]/' /etc/lvm/lvm.conf
      - name: "patch udev_sync, udev_rules on lvm config"
        commands:
        - |

--- a/nvidia-driver-toolkit/Dockerfile
+++ b/nvidia-driver-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensuse.org/isv/rancher/harvester/os/sl-micro-6.1/main/baseos-headers:latest
+FROM registry.opensuse.org/isv/rancher/harvester/os/sl-micro-6.2/main/baseos-headers:latest
 
 ARG TARGETARCH
 RUN curl -kLO "https://dl.k8s.io/release/$(curl -k -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" \


### PR DESCRIPTION
#### Problem:
We need a SL Micro 6.2 based build for testing purposes

#### Solution:
- Update the sl-micro-6 branch to be identical to the current sle-micro branch (that's what all those cherry picks do)
- Change the `FROM` line in the Dockerfiles to point to registry.opensuse.org/isv/rancher/harvester/os/sl-micro-6.2/main/baseos:latest and registry.opensuse.org/isv/rancher/harvester/os/sl-micro-6.2/main/baseos-headers:latest

#### Related Issue(s):
N/A

#### Test plan:
N/A

#### Additional documentation or context
We can use this by making a harvester-installer build with `BASE_OS_IMAGE="rancher/harvester-os:sl-micro-6-head"` instead of `rancher/harvester-os:sle-micro-head`.
