### PR TITLE
chore: update baseos to use v1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos:latest AS base
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.8/main/baseos:v1.8 AS base
 
 ARG CACHEBUST
 

--- a/nvidia-driver-toolkit/Dockerfile
+++ b/nvidia-driver-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos-headers:latest
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.8/main/baseos-headers:v1.8
 
 ARG TARGETARCH
 RUN curl -kLO "https://dl.k8s.io/release/$(curl -k -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" \


### PR DESCRIPTION
#### Problem:
Component update for Harvester v1.8.0

#### Solution:
Bump baseos to use v1.8 artifacts for the v1.8 stable branch.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9978

#### Test plan:
N/A
