### PR TITLE
Pin GH Actions to commit sha

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Get all releases
         id: get_all_releases
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -36,7 +36,7 @@ jobs:
             core.setOutput('allReleases', releases);
       - name: Get v1.8 latest release
         id: get_release_v1_8_x
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             const releases = ${{ steps.get_all_releases.outputs.allReleases }};
@@ -49,7 +49,7 @@ jobs:
             }
       - name: Get v1.7 latest release
         id: get_release_v1_7_x
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             const releases = ${{ steps.get_all_releases.outputs.allReleases }};
@@ -62,7 +62,7 @@ jobs:
             }
       - name: Get v1.6 latest release
         id: get_release_v1_6_x
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             const releases = ${{ steps.get_all_releases.outputs.allReleases }};
@@ -75,7 +75,7 @@ jobs:
             }
       - name: Get v1.5 latest release
         id: get_release_v1_5_x
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             const releases = ${{ steps.get_all_releases.outputs.allReleases }};
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: Set osImage
         id: set_os_image
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             const osImage = `rancher/harvester-os:${{ needs.get-all-releases.outputs.releaseName_v1_8_x }}`;
@@ -126,7 +126,7 @@ jobs:
     steps:
       - name: Set osImage
         id: set_os_image
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             const osImage = `rancher/harvester-os:${{ needs.get-all-releases.outputs.releaseName_v1_7_x }}`;
@@ -156,7 +156,7 @@ jobs:
     steps:
       - name: Set osImage
         id: set_os_image
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             const osImage = `rancher/harvester-os:${{ needs.get-all-releases.outputs.releaseName_v1_6_x }}`;
@@ -186,7 +186,7 @@ jobs:
     steps:
       - name: Set osImage
         id: set_os_image
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             const osImage = `rancher/harvester-os:${{ needs.get-all-releases.outputs.releaseName_v1_5_x }}`;

--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -21,16 +21,16 @@ jobs:
       id-token: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3 
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Read some Secrets
-      uses: rancher-eio/read-vault-secrets@main
+      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
       if: ${{ inputs.push == true }}
       with:
         secrets: |
@@ -38,7 +38,7 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       if: ${{ inputs.push == true }}
       with:
         username: ${{ env.DOCKER_USERNAME }}
@@ -48,7 +48,7 @@ jobs:
       run: bash scripts/ci
 
     - name: Docker Build (OS Image)
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         provenance: false
         context: .
@@ -61,7 +61,7 @@ jobs:
       run: cp nvidia-driver-toolkit/entrypoint.sh .
 
     - name: Docker Build (NV-driver-toolkits Image)
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         provenance: false
         context: .

--- a/.github/workflows/installer-pr.yml
+++ b/.github/workflows/installer-pr.yml
@@ -44,7 +44,7 @@ jobs:
           container-diff diff daemon://docker.io/$BASE_OS_IMAGE daemon://docker.io/${{ env.IMAGE_NAME }} --type=rpm --output=/tmp/diff-result.txt
           cat /tmp/diff-result.txt
       - name: Clone harvester-installer repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: harvester/harvester-installer
           ref: ${{ env.targetVersion }}
@@ -103,7 +103,7 @@ jobs:
         run: |
           echo "targetVersion=$(echo ${{ inputs.tag }} | cut -d'-' -f1)" >> $GITHUB_ENV
       - name: Clone Addons repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: harvester/addons
           ref: ${{ env.targetVersion }}


### PR DESCRIPTION
This PR is part of an org-wide effort to pin GHA action references to immutable commit SHAs. It contains results from the RST `pin-gha-to-sha.sh` script where any `uses:` references to tags or branches are replaced by immutable commit SHAs.

Related to https://github.com/harvester/harvester/issues/10279