### PR TITLE
fix: set use_devicesfile = 0 in lvm.conf

### DIFF
--- a/files/system/oem/91_lvm.yaml
+++ b/files/system/oem/91_lvm.yaml
@@ -5,6 +5,10 @@ stages:
        commands:
        - |
         sed -i 's/^devices.*/&\n\tglobal_filter = [ "r|\/dev\/loop.*|", "r|\/dev\/disk\/by-path\/.*longhorn.*|", "r|\/dev\/mapper\/pvc-.*|" ]/' /etc/lvm/lvm.conf
+     - name: "patch lvm config (set use_devicesfile = 0)"
+       commands:
+       - |
+        sed -i 's/# use_devicesfile = 1/use_devicesfile = 0/' /etc/lvm/lvm.conf
      - name: "patch udev_sync, udev_rules on lvm config"
        commands:
        - |


### PR DESCRIPTION
#### Problem:
SL Micro 6.2 changed the default for use_devicesfile in lvm.conf from 0 to 1.  This means that LVM will try to use the file `/etc/lvm/devices/system.devices` to indicate which devices can and can't be used by LVM.  When using the devices file, the global_filter setting will be ignored.  But, this only actually works if the systemd.devices file exists, which it won't usually. So, we still need our existing global_filter in place by default, so that we can correctly ignore longhorn devices and LVM volumes in VMs.

Where things get weird is, if use_devicesfile=1, and you add a disk to harvester using the LVM provisioner, suddely the devices file will be created automatically, and then subsequent invocations of lvm commands will start printing an annoying error message about removing the global filter:

  ```
  # pvs
  Please remove the lvm.conf global_filter, it is ignored with the devices file.
  PV         VG Fmt  Attr PSize  PFree
  /dev/vdb      lvm2 ---  20.00g 20.00g
  ```
#### Solution:
We can fix this by setting use_devicesfile back to 0, same as it was in earlier versions of Harvester.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8894
https://github.com/harvester/harvester/issues/9342

#### Test plan:
To reproduce the problem, boot the harvester installer for v1.8 (without this fix) on a host with at least one extra disk. Quickest is to do it in a VM. Don't bother running through the install, just log in, become root, and do this:
```
# pvcreate /dev/vdb
  Physical volume "/dev/vdb" successfully created.
  Creating devices file /etc/lvm/devices/system.devices
# pvs
  Please remove the lvm.conf global_filter, it is ignored with the devices file.
  PV         VG Fmt  Attr PSize  PFree 
  /dev/vdb      lvm2 ---  20.00g 20.00g
```

Repeat with the fix applied, and you should see this instead:
```
# pvcreate /dev/vdb
  Physical volume "/dev/vdb" successfully created.
# pvs
  PV         VG Fmt  Attr PSize  PFree 
  /dev/vdb      lvm2 ---  20.00g 20.00g
```