### PR TITLE
`/etc/login.defs` has been relocated to `/usr/etc/login.defs`

### DIFF
--- a/files/etc/login.defs.d/harvester.defs
+++ b/files/etc/login.defs.d/harvester.defs
@@ -1,0 +1,2 @@
+# Change the default umask to `0027` for security.
+UMASK   027

--- a/files/system/oem/85_umask.yaml
+++ b/files/system/oem/85_umask.yaml
@@ -1,7 +1,0 @@
-name: "umask related patch"
-stages:
-   boot:
-     - name: "Change the default umask to `0027` for security"
-       commands:
-       - |
-         sed -i "s/UMASK.*022/UMASK\t\t027/" /etc/login.defs


### PR DESCRIPTION
#### Problem:
The default `login.defs`file has been relocated from `/etc/login.defs` to `/usr/etc/login.defs`. Because of that the file `85_umask.yaml` fails.

References:
- https://bugzilla.opensuse.org/show_bug.cgi?id=1155735

#### Solution:
Create an custom config file at `/etc/login.defs.d/harvester.defs` to override `UMASK`.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10358

#### Test Cases:
***Case 1***
- Log into a node via SSH and run
```
# journalctl -b -t elemental | grep "failed to run sed"
```
No message should be found.

***Case 2***
- Log into a node via SSH and run
```
# ls -alh /etc/login.defs.d/
```
The file `harvester.defs` has to be listed.
- 

***Case 3***
- Run the following command. The output should look like this:
```
# umask 
0027
```
