### PR TITLE
chore: update baseos to use v1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos:latest AS base
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.9/main/baseos:v1.9 AS base
 
 ARG CACHEBUST
 

--- a/nvidia-driver-toolkit/Dockerfile
+++ b/nvidia-driver-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos-headers:latest
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.9/main/baseos-headers:v1.9
 
 ARG TARGETARCH
 RUN VERSION=$(curl -sSfL "https://dl.k8s.io/release/stable.txt") && \


### PR DESCRIPTION
#### Problem:
Component update for Harvester v1.9.0

#### Solution:
Bump baseos to use v1.9 artifacts for the v1.9 stable branch.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10732

#### Test plan:
N/A