### PR TITLE
build: bump rancherd from v0.9.0-rc1 to v0.9.0-rc2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,11 @@ RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/a
 ENV ARCH=${TARGETPLATFORM#linux/}
 
 # Download rancherd
-ARG RANCHERD_VERSION=v0.9.0-rc1
+ARG RANCHERD_VERSION=v0.9.0-rc2
 RUN curl -o /usr/bin/rancherd -sSfL "https://github.com/harvester/rancherd/releases/download/${RANCHERD_VERSION}/rancherd-${ARCH}" && \
     case "${ARCH}" in \
-        amd64) EXPECTED_HASH="9e18273fa09421a0dfc21c7417959d03b0206aa93f41349e1f338c8ac7cde31f" ;; \
-        arm64) EXPECTED_HASH="c9d3bfb5cae7787e826757c4c89abb260597d1007d6669c4122d1572a6d83260" ;; \
+        amd64) EXPECTED_HASH="2d76c64ccb9225c3b1038bace3946849c6330548d10fe160dfa17dd981a8f2af" ;; \
+        arm64) EXPECTED_HASH="663f6def469451596d70ce677f357b9c53d3894fe040bfcecfca97223f270b7a" ;; \
     esac && \
     echo "${EXPECTED_HASH}  /usr/bin/rancherd" | sha256sum -c - && \
     chmod 0755 /usr/bin/rancherd


### PR DESCRIPTION
Release page: https://github.com/harvester/rancherd/releases/tag/v0.9.0-rc2

