### PR TITLE
feat: add harvester-kernel-module-devel image

### DIFF
--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -12,6 +12,7 @@ env:
   repo: "rancher"
   OSImageName: "harvester-os"
   NVDriverToolkitImageName: "harvester-nvidia-driver-toolkit"
+  KernelModuleDevelImageName: "harvester-kernel-module-devel"
 
 jobs:
   build-os-related-images:
@@ -69,3 +70,13 @@ jobs:
         file: nvidia-driver-toolkit/Dockerfile
         push: ${{ inputs.push }}
         tags: ${{ env.repo }}/${{ env.NVDriverToolkitImageName }}:${{ inputs.tag }}
+
+    - name: Docker Build (Kernel Module Devel Image)
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      with:
+        provenance: false
+        context: .
+        platforms: linux/amd64,linux/arm64
+        file: kernel-module-devel/Dockerfile
+        push: ${{ inputs.push }}
+        tags: ${{ env.repo }}/${{ env.KernelModuleDevelImageName }}:${{ inputs.tag }}

--- a/kernel-module-devel/Dockerfile
+++ b/kernel-module-devel/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos-headers:latest
+
+RUN \
+	zypper -n ar --refresh --gpgcheck --priority 100 --enable 'https://public-dl.suse.com/SUSE/Products/SLE-BCI/16.0/$basearch/product/' SLE_BCI && \
+	zypper -n ar --refresh --gpgcheck --priority 100 --disable 'https://public-dl.suse.com/SUSE/Products/SLE-BCI/16.0/$basearch/product_debug/' SLE_BCI_debug && \
+	zypper -n ar --refresh --gpgcheck --priority 100 --disable 'https://public-dl.suse.com/SUSE/Products/SLE-BCI/16.0/$basearch/product_source/' SLE_BCI_source
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
#### Problem:
We need a way of building additional kernel modules to support 3rd party storage drivers for use on Harvester. 

#### Solution:
This adds a new container image, rancher/harvester-kernel-module-devel, which includes the kernel source and related devel packages and tools. This will help anyone who needs to build additional kernel modules for e.g. third party storage drivers.  It also enables the SLE-BCI/16.0 repos inside this container - if any extra BCI packages are needed for building, they can be installed inside the container at runtime.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/11263

#### Test plan:
Use docker or a daemonset (or whatever) to build and load some interesting kernel modules (TBD: flesh this out more)

#### Additional documentation or context
This requires:
- https://build.opensuse.org/request/show/1370816 (a couple of extra useful packages, plus the gpg keys necessary for the BCI repos)
- https://github.com/rancherlabs/eio/issues/4361 (dockerhub repo)

We'll also need to make matching changes to the v1.9 project on OBS, and the v1.9 branch here to pick this up for the v1.9.0 release.