### PR TITLE
feat: add harvester-kernel-module-devel image (backport #271)

### DIFF
--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -12,6 +12,7 @@ env:
   repo: "rancher"
   OSImageName: "harvester-os"
   NVDriverToolkitImageName: "harvester-nvidia-driver-toolkit"
+  KernelModuleDevelImageName: "harvester-kernel-module-devel"
 
 jobs:
   build-os-related-images:
@@ -69,3 +70,13 @@ jobs:
         file: nvidia-driver-toolkit/Dockerfile
         push: ${{ inputs.push }}
         tags: ${{ env.repo }}/${{ env.NVDriverToolkitImageName }}:${{ inputs.tag }}
+
+    - name: Docker Build (Kernel Module Devel Image)
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      with:
+        provenance: false
+        context: .
+        platforms: linux/amd64,linux/arm64
+        file: kernel-module-devel/Dockerfile
+        push: ${{ inputs.push }}
+        tags: ${{ env.repo }}/${{ env.KernelModuleDevelImageName }}:${{ inputs.tag }}

--- a/kernel-module-devel/Dockerfile
+++ b/kernel-module-devel/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.9/main/baseos-headers:v1.9
+
+RUN \
+	zypper -n ar --refresh --gpgcheck --priority 100 --enable 'https://public-dl.suse.com/SUSE/Products/SLE-BCI/16.0/$basearch/product/' SLE_BCI && \
+	zypper -n ar --refresh --gpgcheck --priority 100 --disable 'https://public-dl.suse.com/SUSE/Products/SLE-BCI/16.0/$basearch/product_debug/' SLE_BCI_debug && \
+	zypper -n ar --refresh --gpgcheck --priority 100 --disable 'https://public-dl.suse.com/SUSE/Products/SLE-BCI/16.0/$basearch/product_source/' SLE_BCI_source
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Manual backport of https://github.com/harvester/os2/pull/271 in order to use `registry.opensuse.org/isv/rancher/harvester/os/v1.9/main/baseos-headers:v1.9` in the v1.9 branch (vs. `registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos-headers:latest` in the sle-micro branch).