### PR TITLE
Publish images via harvester-actions registry actions

### DIFF
--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -38,9 +38,11 @@ jobs:
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Generate os-release
+      if: ${{ matrix.image == 'harvester-os' }}
       run: bash scripts/ci
 
     - name: Prepare entrypoint script for NV driver toolkit image
+      if: ${{ matrix.image == 'harvester-nvidia-driver-toolkit' }}
       run: cp nvidia-driver-toolkit/entrypoint.sh .
 
     - name: Resolve registries

--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -9,10 +9,7 @@ on:
         type: boolean
 
 env:
-  repo: "rancher"
-  OSImageName: "harvester-os"
-  NVDriverToolkitImageName: "harvester-nvidia-driver-toolkit"
-  KernelModuleDevelImageName: "harvester-kernel-module-devel"
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build-os-related-images:
@@ -20,6 +17,16 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: harvester-os
+            dockerfile: Dockerfile
+          - image: harvester-nvidia-driver-toolkit
+            dockerfile: nvidia-driver-toolkit/Dockerfile
+          - image: harvester-kernel-module-devel
+            dockerfile: kernel-module-devel/Dockerfile
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -30,53 +37,71 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-    - name: Read some Secrets
-      uses: rancher-eio/read-vault-secrets@d266f55186f80a893839f6e15662e67388e443e6 # main
-      if: ${{ inputs.push == true }}
-      with:
-        secrets: |
-          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-      if: ${{ inputs.push == true }}
-      with:
-        username: ${{ env.DOCKER_USERNAME }}
-        password: ${{ env.DOCKER_PASSWORD }}
-
-    - name: generate os-release
+    - name: Generate os-release
       run: bash scripts/ci
 
-    - name: Docker Build (OS Image)
-      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
-      with:
-        provenance: false
-        context: .
-        platforms: linux/amd64,linux/arm64
-        file: Dockerfile
-        push: ${{ inputs.push }}
-        tags: ${{ env.repo }}/${{ env.OSImageName }}:${{ inputs.tag }}
-
-    - name: prepare entrypoint script for NV-driver-toolkits Image
+    - name: Prepare entrypoint script for NV driver toolkit image
       run: cp nvidia-driver-toolkit/entrypoint.sh .
 
-    - name: Docker Build (NV-driver-toolkits Image)
-      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+    - name: Resolve registries
+      id: resolve
+      uses: harvester/harvester-actions/actions/resolve-registries@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
       with:
-        provenance: false
-        context: .
-        platforms: linux/amd64,linux/arm64
-        file: nvidia-driver-toolkit/Dockerfile
-        push: ${{ inputs.push }}
-        tags: ${{ env.repo }}/${{ env.NVDriverToolkitImageName }}:${{ inputs.tag }}
+        release-tag-name: ${{ inputs.tag }}
+        is-release: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
 
-    - name: Docker Build (Kernel Module Devel Image)
-      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+    - name: Set image tag
+      run: echo "IMAGE_TAG=${TAG#prime-}" >> "$GITHUB_ENV"
+      env:
+        TAG: ${{ inputs.tag }}
+
+    - name: Login to Docker Hub
+      id: login-docker
+      if: ${{ inputs.push == true && steps.resolve.outputs.use-docker-io == 'true' }}
+      uses: harvester/harvester-actions/actions/login-docker-hub@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+
+    - name: Publish public ${{ matrix.image }} image
+      if: ${{ inputs.push == true && steps.resolve.outputs.use-docker-io == 'true' }}
+      uses: harvester/harvester-actions/actions/publish-public-image@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
       with:
-        provenance: false
         context: .
-        platforms: linux/amd64,linux/arm64
-        file: kernel-module-devel/Dockerfile
-        push: ${{ inputs.push }}
-        tags: ${{ env.repo }}/${{ env.KernelModuleDevelImageName }}:${{ inputs.tag }}
+        dockerfile: ${{ matrix.dockerfile }}
+        image: ${{ matrix.image }}
+        tag: ${{ env.IMAGE_TAG }}
+        platforms: ${{ env.PLATFORMS }}
+        registry: ${{ steps.login-docker.outputs.registry }}
+        repository: ${{ steps.login-docker.outputs.repository }}
+
+    - name: Login to Staging Registry
+      id: login-staging
+      if: ${{ inputs.push == true && steps.resolve.outputs.use-staging == 'true' }}
+      uses: harvester/harvester-actions/actions/login-staging-registry@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+
+    - name: Publish staging ${{ matrix.image }} image
+      if: ${{ inputs.push == true && steps.resolve.outputs.use-staging == 'true' }}
+      uses: harvester/harvester-actions/actions/publish-prime-image@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+      with:
+        context: .
+        dockerfile: ${{ matrix.dockerfile }}
+        image: ${{ matrix.image }}
+        tag: ${{ env.IMAGE_TAG }}
+        platforms: ${{ env.PLATFORMS }}
+        registry: ${{ steps.login-staging.outputs.registry }}
+        repository: ${{ steps.login-staging.outputs.repository }}
+
+    - name: Login to Prime Registry
+      id: login-prime
+      if: ${{ inputs.push == true && steps.resolve.outputs.use-prime == 'true' }}
+      uses: harvester/harvester-actions/actions/login-prime-registry@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+
+    - name: Publish prime ${{ matrix.image }} image
+      if: ${{ inputs.push == true && steps.resolve.outputs.use-prime == 'true' }}
+      uses: harvester/harvester-actions/actions/publish-prime-image@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+      with:
+        context: .
+        dockerfile: ${{ matrix.dockerfile }}
+        image: ${{ matrix.image }}
+        tag: ${{ env.IMAGE_TAG }}
+        platforms: ${{ env.PLATFORMS }}
+        registry: ${{ steps.login-prime.outputs.registry }}
+        repository: ${{ steps.login-prime.outputs.repository }}


### PR DESCRIPTION
- Use the shared harvester/harvester-actions actions so images are conditionally published to docker.io, the staging registry, and the prime registry.
  - Branch merge: push to the public and staging registries.
  - Tag (v*): push to the public registry.
  - Tag (`prime-*`): push to the prime registry.

Note: need to refer to https://github.com/harvester/harvester-actions for actions